### PR TITLE
BAU: Fix startup.sh to work with latest version of verify-local-startup

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -22,7 +22,7 @@ printf "Starting... "
 ./gradlew run > logs/verify-matching-service-adapter_console.log 2>&1 &
 if test -d ../verify-local-startup; then
     source ../verify-local-startup/lib/services.sh
-    ( start_service_checker $port "Unknown" "logs/verify-matching-service-adapter_console.log"
+    ( start_service_checker "matching-service-adapter" $port "Unknown" "logs/verify-matching-service-adapter_console.log" "localhost:$port/service-status"
         wait )
 else
     sleep 10


### PR DESCRIPTION
Authors: @rachaelbooth