### PR TITLE
bau: Test tool - close file resources after use

### DIFF
--- a/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/LevelOfAssuranceOneScenario.java
+++ b/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/LevelOfAssuranceOneScenario.java
@@ -22,7 +22,7 @@ public class LevelOfAssuranceOneScenario extends ScenarioBase {
 
     @Test
     @DisplayName("Simple request with level of assurance 1")
-    public void runForSimpleCase() {
+    public void runForSimpleCase() throws Exception {
         Response response = client.target(configuration.getLocalMatchingServiceMatchUrl())
             .request(APPLICATION_JSON)
             .post(Entity.json(fileUtils.readFromResources("LoA1-simple-case.json")));
@@ -32,7 +32,7 @@ public class LevelOfAssuranceOneScenario extends ScenarioBase {
 
     @Test
     @DisplayName("Complex request with level of assurance 1")
-    public void runForComplexCase() {
+    public void runForComplexCase() throws Exception {
         String jsonString = fileUtils.readFromResources("LoA1-extensive-case.json")
             .replace("%yesterdayDate%", Instant.now().minus(1, DAYS).toString())
             .replace("%within405days-100days%", Instant.now().minus(405-100, DAYS).toString())

--- a/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/LevelOfAssuranceTwoScenario.java
+++ b/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/LevelOfAssuranceTwoScenario.java
@@ -22,7 +22,7 @@ public class LevelOfAssuranceTwoScenario extends ScenarioBase {
 
     @Test
     @DisplayName("Simple request with level of assurance 2")
-    public void runForWhenAllElementsAreVerifiedAndNoMultipleValues() {
+    public void runForWhenAllElementsAreVerifiedAndNoMultipleValues() throws Exception {
         Response response = client.target(configuration.getLocalMatchingServiceMatchUrl())
             .request(APPLICATION_JSON)
             .post(Entity.json(fileUtils.readFromResources("LoA2-simple-case.json")));
@@ -32,7 +32,7 @@ public class LevelOfAssuranceTwoScenario extends ScenarioBase {
 
     @Test
     @DisplayName("Complex request with level of assurance 2")
-    public void runForComplexCase() {
+    public void runForComplexCase() throws Exception {
         String jsonString = fileUtils.readFromResources("LoA2-extensive-case.json")
             .replace("%yesterdayDate%", Instant.now().minus(1, DAYS).toString())
             .replace("%within405days-100days%", Instant.now().minus(405-100, DAYS).toString())

--- a/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/OptionalAddressFieldsExcludedScenario.java
+++ b/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/OptionalAddressFieldsExcludedScenario.java
@@ -20,7 +20,7 @@ public class OptionalAddressFieldsExcludedScenario extends ScenarioBase {
 
     @Test
     @DisplayName("Simple request with address missing optional fields")
-    public void runCase() {
+    public void runCase() throws Exception {
         Response response = client.target(configuration.getLocalMatchingServiceMatchUrl())
             .request(APPLICATION_JSON)
             .post(Entity.json(fileUtils.readFromResources("simple-case-excluding-optional-address-fields.json")));

--- a/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/UserAccountCreationScenario.java
+++ b/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/UserAccountCreationScenario.java
@@ -25,7 +25,7 @@ public class UserAccountCreationScenario extends ScenarioBase {
         "(remove accountCreationUrl from verify-matching-service-test-tool.yml " +
         "to skip this if you don't need to test account creation)"
     )
-    public void runForUserAccountCreation() {
+    public void runForUserAccountCreation() throws Exception {
         assumeTrue(
             configuration.getLocalMatchingServiceAccountCreationUrl() != null,
             "Test aborted as no user account creation is not configured."

--- a/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/utils/FileUtils.java
+++ b/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/utils/FileUtils.java
@@ -3,7 +3,7 @@ package uk.gov.ida.verifymatchingservicetesttool.utils;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
@@ -12,7 +12,7 @@ import static java.util.stream.Collectors.joining;
 
 public class FileUtils {
 
-    public String readFromResources(String fileName) {
+    public String readFromResources(String fileName) throws IOException {
         InputStream inputStream = this.getClass()
             .getClassLoader()
             .getResourceAsStream(fileName);
@@ -20,14 +20,17 @@ public class FileUtils {
         return readFrom(inputStream);
     }
 
-    public String read(File file) throws FileNotFoundException {
-        FileInputStream inputStream = new FileInputStream(file);
-        return readFrom(inputStream);
+    public String read(File file) throws IOException {
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            return readFrom(inputStream);
+        }
     }
 
-    private String readFrom(InputStream inputStream) {
-        return new BufferedReader(new InputStreamReader(inputStream))
-            .lines()
-            .collect(joining(lineSeparator()));
+    private String readFrom(InputStream inputStream) throws IOException {
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream))) {
+            return bufferedReader
+                .lines()
+                .collect(joining(lineSeparator()));
+        }
     }
 }


### PR DESCRIPTION
We weren't closing the examples files after reading them, which seems to
have been causing the occasional weird thing to happen now we're
calling `System.exit()`.

I'm using a try-with-resources statement to close the Closeable classes
in FileUtils: https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html

Authors: @richardtowers