### PR TITLE
TT-1601 Integration tests ensure that the MSA can generate test tool …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ def dependencyVersions = [
         saml_test_utils:"$opensaml-33",
         saml_domain_objects: "$opensaml-40",
         hub_saml: "$opensaml-98",
-        dev_pki: '1.1.0-19',
+        dev_pki: '1.1.0-19'
 ]
 
 apply plugin: "idaJar"
@@ -60,10 +60,6 @@ configurations {
 }
 
 configurations.all {
-    resolutionStrategy {
-        // dropwizard-testing uses 2.2.0 but our libraries currently only work with 1.6.0.
-        force "org.assertj:assertj-core:1.6.0"
-    }
     resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
 }
 
@@ -128,11 +124,12 @@ dependencies {
         "io.dropwizard:dropwizard-testing:$dependencyVersions.dropwizard",
         "io.dropwizard:dropwizard-jackson:$dependencyVersions.dropwizard",
         'org.mockito:mockito-core:1.10.19',
-        'org.assertj:assertj-core:1.6.0',
+        'org.assertj:assertj-core:3.8.0',
         'org.assertj:assertj-joda-time:1.1.0',
         'com.google.code.findbugs:jsr305:3.0.1',
         "uk.gov.ida:hub-saml-test-utils:$dependencyVersions.hub_saml",
-        "uk.gov.ida:common-test-utils:2.0.0-$dependencyVersions.ida_test_utils"
+        "uk.gov.ida:common-test-utils:2.0.0-$dependencyVersions.ida_test_utils",
+        "com.github.tomakehurst:wiremock:2.10.1"
 }
 
 sourceSets {

--- a/src/integration-test/java/uk/gov/ida/integrationtest/TestToolInterfaceMatching/TestToolExamplesSchemaTests.java
+++ b/src/integration-test/java/uk/gov/ida/integrationtest/TestToolInterfaceMatching/TestToolExamplesSchemaTests.java
@@ -57,13 +57,13 @@ public class TestToolExamplesSchemaTests {
     private static final String REQUEST_ID = "default-match-id";
     private static final String PID = "default-pid";
     private static final ObjectMapper objectMapper = Jackson.newObjectMapper().setDateFormat(ISO8601DateFormat.getDateInstance());
-    private static final Integer replaceYesterday = 1;
-    private static final Integer replace405to100 = 100;
-    private static final Integer replace405to101 = 150;
-    private static final Integer replace405to200 = 400;
-    private static final Integer replace180to100 = 100;
-    private static final Integer replace180to101 = 140;
-    private static final Integer replace180to150 = 160;
+    private static final Integer yesterday = 1;
+    private static final Integer inRange405to100 = 100;
+    private static final Integer inRange405to101 = 150;
+    private static final Integer inRange405to200 = 400;
+    private static final Integer inRange180to100 = 100;
+    private static final Integer inRange180to101 = 140;
+    private static final Integer inRange180to150 = 160;
 
     @ClassRule
     public static WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig().port(1234));
@@ -300,7 +300,7 @@ public class TestToolExamplesSchemaTests {
                             aPersonNameValue()
                                 .withValue("Dou")
                                 .withVerified(false)
-                                .withFrom(getDateReplacement(replaceYesterday))
+                                .withFrom(getDateReplacement(yesterday))
                                 .withTo(null)
                                 .build()
                         ).addValue(
@@ -315,14 +315,14 @@ public class TestToolExamplesSchemaTests {
                                 .withValue("Joe")
                                 .withVerified(true)
                                 .withFrom(new DateTime(2005, 5, 24, 0, 0, DateTimeZone.UTC))
-                                .withTo(getDateReplacement(replace405to100))
+                                .withTo(getDateReplacement(inRange405to100))
                                 .build()
                         ).addValue(
                             aPersonNameValue()
                                 .withValue("Simon")
                                 .withVerified(false)
-                                .withFrom(getDateReplacement(replace405to101))
-                                .withTo(getDateReplacement(replace405to200))
+                                .withFrom(getDateReplacement(inRange405to101))
+                                .withTo(getDateReplacement(inRange405to200))
                                 .build()
                         )
                         .buildAsSurname(),
@@ -337,7 +337,7 @@ public class TestToolExamplesSchemaTests {
                     anAddressAttribute().addAddress(
                         anAddressAttributeValue()
                             .addLines(asList("2323 George Street"))
-                            .withFrom(getDateReplacement(replaceYesterday))
+                            .withFrom(getDateReplacement(yesterday))
                             .withInternationalPostcode("GB1 5PP")
                             .withPostcode("GB1 2PP")
                             .withUprn("7D68E096-5510-B3844C0BA3FD")
@@ -360,7 +360,7 @@ public class TestToolExamplesSchemaTests {
                             anAddressAttributeValue()
                                 .addLines(asList("344 George Street"))
                                 .withFrom(new DateTime(2009, 5, 24, 0, 0, DateTimeZone.UTC))
-                                .withTo(getDateReplacement(replace405to100))
+                                .withTo(getDateReplacement(inRange405to100))
                                 .withPostcode("GB1 2PP")
                                 .withInternationalPostcode("GB1 2PP")
                                 .withUprn("7D68E096-5510-B3844C0BA3FD")
@@ -369,8 +369,8 @@ public class TestToolExamplesSchemaTests {
                         ).addAddress(
                             anAddressAttributeValue()
                                 .addLines(asList("67676 George Street"))
-                                .withFrom(getDateReplacement(replace405to101))
-                                .withTo(getDateReplacement(replace405to200))
+                                .withFrom(getDateReplacement(inRange405to101))
+                                .withTo(getDateReplacement(inRange405to200))
                                 .withPostcode("GB1 2PP")
                                 .withInternationalPostcode("GB1 3PP")
                                 .withUprn("7D68E096-5510-B3844C0BA3FD")
@@ -441,7 +441,7 @@ public class TestToolExamplesSchemaTests {
                         aPersonNameValue()
                             .withValue("Dou")
                             .withVerified(false)
-                            .withFrom(getDateReplacement(replaceYesterday))
+                            .withFrom(getDateReplacement(yesterday))
                             .withTo(null)
                             .build()
                     ).addValue(
@@ -456,14 +456,14 @@ public class TestToolExamplesSchemaTests {
                             .withValue("Joe")
                             .withVerified(true)
                             .withFrom(new DateTime(2005, 5, 24, 0, 0, DateTimeZone.UTC))
-                            .withTo(getDateReplacement(replace180to100))
+                            .withTo(getDateReplacement(inRange180to100))
                             .build()
                     ).addValue(
                         aPersonNameValue()
                             .withValue("Simon")
                             .withVerified(false)
-                            .withFrom(getDateReplacement(replace180to101))
-                            .withTo(getDateReplacement(replace180to150))
+                            .withFrom(getDateReplacement(inRange180to101))
+                            .withTo(getDateReplacement(inRange180to150))
                             .build()
                     )
                         .buildAsSurname(),
@@ -478,7 +478,7 @@ public class TestToolExamplesSchemaTests {
                     anAddressAttribute().addAddress(
                         anAddressAttributeValue()
                             .addLines(asList("2323 George Street"))
-                            .withFrom(getDateReplacement(replaceYesterday))
+                            .withFrom(getDateReplacement(yesterday))
                             .withInternationalPostcode("GB1 5PP")
                             .withPostcode("GB1 2PP")
                             .withUprn("7D68E096-5510-B3844C0BA3FD")
@@ -501,7 +501,7 @@ public class TestToolExamplesSchemaTests {
                         anAddressAttributeValue()
                             .addLines(asList("344 George Street"))
                             .withFrom(new DateTime(2009, 5, 24, 0, 0, DateTimeZone.UTC))
-                            .withTo(getDateReplacement(replace405to100))
+                            .withTo(getDateReplacement(inRange405to100))
                             .withPostcode("GB1 2PP")
                             .withInternationalPostcode("GB1 2PP")
                             .withUprn("7D68E096-5510-B3844C0BA3FD")
@@ -510,8 +510,8 @@ public class TestToolExamplesSchemaTests {
                     ).addAddress(
                         anAddressAttributeValue()
                             .addLines(asList("67676 George Street"))
-                            .withFrom(getDateReplacement(replace405to101))
-                            .withTo(getDateReplacement(replace405to200))
+                            .withFrom(getDateReplacement(inRange405to101))
+                            .withTo(getDateReplacement(inRange405to200))
                             .withPostcode("GB1 2PP")
                             .withInternationalPostcode("GB1 3PP")
                             .withUprn("7D68E096-5510-B3844C0BA3FD")
@@ -547,7 +547,7 @@ public class TestToolExamplesSchemaTests {
     }
 
     @Test
-    public void shouldProducesUserAccountCreationJson() throws Exception {
+    public void shouldProduceUserAccountCreationJson() throws Exception {
         AttributeQuery attributeQuery = AttributeQueryBuilder.anAttributeQuery()
             .withId(REQUEST_ID)
             .withAttributes(asList())
@@ -594,13 +594,13 @@ public class TestToolExamplesSchemaTests {
     }
 
     private String makeDateReplacements(String input) {
-        return input.replace("%yesterdayDate%", getDateReplacement(replaceYesterday).toString())
-            .replace("%within405days-100days%", getDateReplacement(replace405to100).toString())
-            .replace("%within405days-101days%", getDateReplacement(replace405to101).toString())
-            .replace("%within405days-200days%", getDateReplacement(replace405to200).toString())
-            .replace("%within180days-100days%", getDateReplacement(replace180to100).toString())
-            .replace("%within180days-101days%", getDateReplacement(replace180to101).toString())
-            .replace("%within180days-150days%", getDateReplacement(replace180to150).toString());
+        return input.replace("%yesterdayDate%", getDateReplacement(yesterday).toString())
+            .replace("%within405days-100days%", getDateReplacement(inRange405to100).toString())
+            .replace("%within405days-101days%", getDateReplacement(inRange405to101).toString())
+            .replace("%within405days-200days%", getDateReplacement(inRange405to200).toString())
+            .replace("%within180days-100days%", getDateReplacement(inRange180to100).toString())
+            .replace("%within180days-101days%", getDateReplacement(inRange180to101).toString())
+            .replace("%within180days-150days%", getDateReplacement(inRange180to150).toString());
     }
 
     private DateTime getDateReplacement(Integer daysToSubtract) {

--- a/src/integration-test/java/uk/gov/ida/integrationtest/TestToolInterfaceMatching/TestToolExamplesSchemaTests.java
+++ b/src/integration-test/java/uk/gov/ida/integrationtest/TestToolInterfaceMatching/TestToolExamplesSchemaTests.java
@@ -1,0 +1,611 @@
+package uk.gov.ida.integrationtest.TestToolInterfaceMatching;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.xmlsec.algorithm.DigestAlgorithm;
+import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
+import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA256;
+import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA1;
+import uk.gov.ida.integrationtest.helpers.MatchingServiceAdapterAppRule;
+import uk.gov.ida.matchingserviceadapter.MatchingServiceAdapterConfiguration;
+import uk.gov.ida.saml.core.extensions.IdaAuthnContext;
+import uk.gov.ida.saml.core.test.builders.AttributeQueryBuilder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.integrationtest.helpers.AssertionHelper.aMatchingDatasetAssertion;
+import static uk.gov.ida.integrationtest.helpers.AssertionHelper.aSubjectWithAssertions;
+import static uk.gov.ida.integrationtest.helpers.AssertionHelper.anAuthnStatementAssertion;
+import static uk.gov.ida.integrationtest.helpers.RequestHelper.makeAttributeQueryRequest;
+import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_ENTITY_ID;
+import static uk.gov.ida.saml.core.test.builders.AddressAttributeBuilder_1_1.anAddressAttribute;
+import static uk.gov.ida.saml.core.test.builders.AddressAttributeValueBuilder_1_1.anAddressAttributeValue;
+import static uk.gov.ida.saml.core.test.builders.DateAttributeBuilder_1_1.aDate_1_1;
+import static uk.gov.ida.saml.core.test.builders.DateAttributeValueBuilder.aDateValue;
+import static uk.gov.ida.saml.core.test.builders.GenderAttributeBuilder_1_1.aGender_1_1;
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+import static uk.gov.ida.saml.core.test.builders.PersonNameAttributeBuilder_1_1.aPersonName_1_1;
+import static uk.gov.ida.saml.core.test.builders.PersonNameAttributeValueBuilder.aPersonNameValue;
+
+public class TestToolExamplesSchemaTests {
+    private final SignatureAlgorithm signatureAlgorithmForHub = new SignatureRSASHA1();
+    private final DigestAlgorithm digestAlgorithmForHub = new DigestSHA256();
+    private static final String REQUEST_ID = "default-match-id";
+    private static final String PID = "default-pid";
+    private static final ObjectMapper objectMapper = Jackson.newObjectMapper().setDateFormat(ISO8601DateFormat.getDateInstance());
+    private static final Integer replaceYesterday = 1;
+    private static final Integer replace405to100 = 100;
+    private static final Integer replace405to101 = 150;
+    private static final Integer replace405to200 = 400;
+    private static final Integer replace180to100 = 100;
+    private static final Integer replace180to101 = 140;
+    private static final Integer replace180to150 = 160;
+
+    @ClassRule
+    public static WireMockClassRule wireMockRule = new WireMockClassRule(wireMockConfig().port(1234));
+
+    @ClassRule
+    public static final DropwizardAppRule<MatchingServiceAdapterConfiguration> applicationRule = new MatchingServiceAdapterAppRule(
+        ConfigOverride.config("localMatchingService.matchUrl", "http://localhost:1234/match"),
+        ConfigOverride.config("localMatchingService.accountCreationUrl", "http://localhost:1234/user-account-creation")
+    );
+
+    private final String MATCHING_SERVICE_URI = "http://localhost:" + applicationRule.getLocalPort() + "/matching-service/POST";
+    private final String UNKNOWN_USER_URI = "http://localhost:" + applicationRule.getLocalPort() + "/unknown-user-attribute-query";
+
+    @BeforeClass
+    public static void setUp() {
+        stubFor(post("/match").willReturn(okJson("{\"result\": \"match\"}")));
+        stubFor(post("/user-account-creation").willReturn(okJson("{\"result\": \"success\"}")));
+    }
+
+    @Before
+    public void reset() {
+        wireMockRule.resetRequests();
+    }
+
+    @Test
+    public void shouldProduceLoA2SimpleCase() throws Exception {
+        AttributeQuery attributeQuery = AttributeQueryBuilder.anAttributeQuery()
+            .withId(REQUEST_ID)
+            .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+            .withSubject(aSubjectWithAssertions(asList(
+                anAuthnStatementAssertion(IdaAuthnContext.LEVEL_2_AUTHN_CTX, REQUEST_ID),
+                aMatchingDatasetAssertion(asList(
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Joe")
+                            .withVerified(true)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build())
+                        .buildAsFirstname(),
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Bob Rob")
+                            .withVerified(true)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build())
+                        .buildAsMiddlename(),
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Dou")
+                            .withVerified(true)
+                            .withFrom(new DateTime(2010, 1, 20, 0, 0, DateTimeZone.UTC))
+                            .withTo(null)
+                            .build())
+                        .buildAsSurname(),
+                    aGender_1_1().withValue("Male").withVerified(true).withFrom(null).withTo(null).build(),
+                    aDate_1_1().addValue(
+                        aDateValue()
+                            .withValue("1980-05-24")
+                            .withVerified(true)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build()).buildAsDateOfBirth(),
+                    anAddressAttribute().addAddress(
+                        anAddressAttributeValue()
+                            .addLines(asList("10 George Street"))
+                            .withFrom(new DateTime(2005, 5, 14, 0, 0, DateTimeZone.UTC))
+                            .withInternationalPostcode("GB1 2PF")
+                            .withPostcode("GB1 2PF")
+                            .withUprn("833F1187-9F33-A7E27B3F211E")
+                            .withVerified(true)
+                            .withTo(null)
+                            .build())
+                        .buildCurrentAddress()
+                ), false, REQUEST_ID)), REQUEST_ID, HUB_ENTITY_ID, PID))
+            .build();
+
+        Path path = Paths.get("verify-matching-service-test-tool/src/main/resources/LoA2-simple-case.json");
+
+        assertThatRequestThatWillBeSentIsEquivalentToFile(attributeQuery, path);
+    }
+
+    @Test
+    public void shouldProduceLoA2SimpleExcludingOptionalAddressFieldsCase() throws Exception {
+        AttributeQuery attributeQuery = AttributeQueryBuilder.anAttributeQuery()
+            .withId(REQUEST_ID)
+            .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+            .withSubject(aSubjectWithAssertions(asList(
+                anAuthnStatementAssertion(IdaAuthnContext.LEVEL_2_AUTHN_CTX, REQUEST_ID),
+                aMatchingDatasetAssertion(asList(
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Joe")
+                            .withVerified(true)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build())
+                        .buildAsFirstname(),
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Bob Rob")
+                            .withVerified(true)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build())
+                        .buildAsMiddlename(),
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Dou")
+                            .withVerified(true)
+                            .withFrom(new DateTime(2010, 01, 20, 0, 0, DateTimeZone.UTC))
+                            .withTo(null)
+                            .build())
+                        .buildAsSurname(),
+                    aGender_1_1().withValue("Male").withVerified(true).withFrom(null).withTo(null).build(),
+                    aDate_1_1().addValue(
+                        aDateValue()
+                            .withValue("1980-05-24")
+                            .withVerified(true)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build()).buildAsDateOfBirth(),
+                    anAddressAttribute().addAddress(
+                        anAddressAttributeValue()
+                            .withFrom(new DateTime(2005, 5, 14, 0, 0, DateTimeZone.UTC))
+                            .withInternationalPostcode(null)
+                            .withPostcode(null)
+                            .withUprn(null)
+                            .withVerified(true)
+                            .withTo(null)
+                            .build())
+                        .buildCurrentAddress()
+                ), false, REQUEST_ID)), REQUEST_ID, HUB_ENTITY_ID, PID))
+            .build();
+
+        Path path = Paths.get("verify-matching-service-test-tool/src/main/resources/simple-case-excluding-optional-address-fields.json");
+
+        assertThatRequestThatWillBeSentIsEquivalentToFile(attributeQuery, path);
+    }
+
+    @Test
+    public void shouldProduceLoA1SimpleCase() throws Exception {
+        AttributeQuery attributeQuery = AttributeQueryBuilder.anAttributeQuery()
+            .withId(REQUEST_ID)
+            .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+            .withSubject(aSubjectWithAssertions(asList(
+                anAuthnStatementAssertion(IdaAuthnContext.LEVEL_1_AUTHN_CTX, REQUEST_ID),
+                aMatchingDatasetAssertion(asList(
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Joe")
+                            .withVerified(true)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build())
+                        .buildAsFirstname(),
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Bob Rob")
+                            .withVerified(true)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build())
+                        .buildAsMiddlename(),
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Dou")
+                            .withVerified(true)
+                            .withFrom(new DateTime(2015, 5, 14, 0, 0, DateTimeZone.UTC))
+                            .withTo(null)
+                            .build())
+                        .buildAsSurname(),
+                    aGender_1_1().withValue("Male").withVerified(true).withFrom(null).withTo(null).build(),
+                    aDate_1_1().addValue(
+                        aDateValue()
+                            .withValue("1980-05-24")
+                            .withVerified(true)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build()).buildAsDateOfBirth(),
+                    anAddressAttribute().addAddress(
+                        anAddressAttributeValue()
+                            .addLines(asList("10 George Street"))
+                            .withFrom(new DateTime(2005, 5, 14, 0, 0, DateTimeZone.UTC))
+                            .withInternationalPostcode("GB1 2PF")
+                            .withPostcode("GB1 2PF")
+                            .withUprn("833F1187-9F33-A7E27B3F211E")
+                            .withVerified(true)
+                            .withTo(null)
+                            .build())
+                        .buildCurrentAddress()
+                ), false, REQUEST_ID)), REQUEST_ID, HUB_ENTITY_ID, PID))
+            .build();
+
+        Path path = Paths.get("verify-matching-service-test-tool/src/main/resources/LoA1-simple-case.json");
+
+        assertThatRequestThatWillBeSentIsEquivalentToFile(attributeQuery, path);
+    }
+
+    @Test
+    public void shouldProduceLoA1ExtensiveCase() throws Exception {
+        AttributeQuery attributeQuery = AttributeQueryBuilder.anAttributeQuery()
+            .withId(REQUEST_ID)
+            .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+            .withSubject(aSubjectWithAssertions(asList(
+                anAuthnStatementAssertion(IdaAuthnContext.LEVEL_1_AUTHN_CTX, REQUEST_ID),
+                aMatchingDatasetAssertion(asList(
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Joe")
+                            .withVerified(false)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build())
+                        .buildAsFirstname(),
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Bob Rob")
+                            .withVerified(false)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build())
+                        .buildAsMiddlename(),
+                    aPersonName_1_1()
+                        .addValue(
+                            aPersonNameValue()
+                                .withValue("Fred")
+                                .withVerified(false)
+                                .withFrom(new DateTime(1980, 5, 24, 0, 0, DateTimeZone.UTC))
+                                .withTo(new DateTime(1987, 1, 20, 0, 0, DateTimeZone.UTC))
+                                .build()
+                        ).addValue(
+                            aPersonNameValue()
+                                .withValue("Dou")
+                                .withVerified(false)
+                                .withFrom(getDateReplacement(replaceYesterday))
+                                .withTo(null)
+                                .build()
+                        ).addValue(
+                            aPersonNameValue()
+                                .withValue("John")
+                                .withVerified(true)
+                                .withFrom(new DateTime(2003, 5, 24, 0, 0, DateTimeZone.UTC))
+                                .withTo(new DateTime(2004, 1, 20, 0, 0, DateTimeZone.UTC))
+                                .build()
+                        ).addValue(
+                            aPersonNameValue()
+                                .withValue("Joe")
+                                .withVerified(true)
+                                .withFrom(new DateTime(2005, 5, 24, 0, 0, DateTimeZone.UTC))
+                                .withTo(getDateReplacement(replace405to100))
+                                .build()
+                        ).addValue(
+                            aPersonNameValue()
+                                .withValue("Simon")
+                                .withVerified(false)
+                                .withFrom(getDateReplacement(replace405to101))
+                                .withTo(getDateReplacement(replace405to200))
+                                .build()
+                        )
+                        .buildAsSurname(),
+                    aGender_1_1().withValue("Male").withVerified(false).withFrom(null).withTo(null).build(),
+                    aDate_1_1().addValue(
+                        aDateValue()
+                            .withValue("1980-05-24")
+                            .withVerified(true)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build()).buildAsDateOfBirth(),
+                    anAddressAttribute().addAddress(
+                        anAddressAttributeValue()
+                            .addLines(asList("2323 George Street"))
+                            .withFrom(getDateReplacement(replaceYesterday))
+                            .withInternationalPostcode("GB1 5PP")
+                            .withPostcode("GB1 2PP")
+                            .withUprn("7D68E096-5510-B3844C0BA3FD")
+                            .withVerified(false)
+                            .withTo(null)
+                            .build())
+                        .buildCurrentAddress(),
+                    anAddressAttribute()
+                        .addAddress(
+                            anAddressAttributeValue()
+                                .addLines(asList("10 George Street"))
+                                .withFrom(new DateTime(2005, 5, 14, 0, 0, DateTimeZone.UTC))
+                                .withTo(new DateTime(2007, 5, 14, 0, 0, DateTimeZone.UTC))
+                                .withPostcode("GB1 2PF")
+                                .withInternationalPostcode("GB1 2PF")
+                                .withUprn("833F1187-9F33-A7E27B3F211E")
+                                .withVerified(true)
+                                .build()
+                        ).addAddress(
+                            anAddressAttributeValue()
+                                .addLines(asList("344 George Street"))
+                                .withFrom(new DateTime(2009, 5, 24, 0, 0, DateTimeZone.UTC))
+                                .withTo(getDateReplacement(replace405to100))
+                                .withPostcode("GB1 2PP")
+                                .withInternationalPostcode("GB1 2PP")
+                                .withUprn("7D68E096-5510-B3844C0BA3FD")
+                                .withVerified(true)
+                                .build()
+                        ).addAddress(
+                            anAddressAttributeValue()
+                                .addLines(asList("67676 George Street"))
+                                .withFrom(getDateReplacement(replace405to101))
+                                .withTo(getDateReplacement(replace405to200))
+                                .withPostcode("GB1 2PP")
+                                .withInternationalPostcode("GB1 3PP")
+                                .withUprn("7D68E096-5510-B3844C0BA3FD")
+                                .withVerified(false)
+                                .build()
+                        ).addAddress(
+                            anAddressAttributeValue()
+                                .addLines(asList("46244 George Street"))
+                                .withFrom(new DateTime(1980, 5, 24, 0, 0, DateTimeZone.UTC))
+                                .withTo(new DateTime(1987, 5, 24, 0, 0, DateTimeZone.UTC))
+                                .withPostcode("GB1 2PP")
+                                .withInternationalPostcode("GB1 3PP")
+                                .withUprn("7D68E096-5510-B3844C0BA3FD")
+                                .withVerified(false)
+                                .build()
+                        ).addAddress(
+                            anAddressAttributeValue()
+                                .addLines(asList("Flat , Alberta Court", "36 Harrods Road", "New Berkshire", "Berkshire", "Cambria", "Europe"))
+                                .withFrom(new DateTime(1987, 5, 24, 0, 0, DateTimeZone.UTC))
+                                .withTo(new DateTime(1989, 5, 24, 0, 0, DateTimeZone.UTC))
+                                .withPostcode(null)
+                                .withInternationalPostcode(null)
+                                .withUprn(null)
+                                .withVerified(false)
+                                .build()
+                        ).buildPreviousAddress()
+                ), false, REQUEST_ID)), REQUEST_ID, HUB_ENTITY_ID, PID))
+            .build();
+
+        Path path = Paths.get("verify-matching-service-test-tool/src/main/resources/LoA1-extensive-case.json");
+
+        assertThatRequestThatWillBeSentIsEquivalentToFile(attributeQuery, path);
+    }
+
+    @Test
+    public void shouldProduceLoA2ExtensiveCase() throws Exception {
+        AttributeQuery attributeQuery = AttributeQueryBuilder.anAttributeQuery()
+            .withId(REQUEST_ID)
+            .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+            .withSubject(aSubjectWithAssertions(asList(
+                anAuthnStatementAssertion(IdaAuthnContext.LEVEL_2_AUTHN_CTX, REQUEST_ID),
+                aMatchingDatasetAssertion(asList(
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Joe")
+                            .withVerified(false)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build())
+                        .buildAsFirstname(),
+                    aPersonName_1_1().addValue(
+                        aPersonNameValue()
+                            .withValue("Bob Rob")
+                            .withVerified(false)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build())
+                        .buildAsMiddlename(),
+                    aPersonName_1_1()
+                        .addValue(
+                            aPersonNameValue()
+                                .withValue("Fred")
+                                .withVerified(false)
+                                .withFrom(new DateTime(1980, 5, 24, 0, 0, DateTimeZone.UTC))
+                                .withTo(new DateTime(1987, 1, 20, 0, 0, DateTimeZone.UTC))
+                                .build()
+                        ).addValue(
+                        aPersonNameValue()
+                            .withValue("Dou")
+                            .withVerified(false)
+                            .withFrom(getDateReplacement(replaceYesterday))
+                            .withTo(null)
+                            .build()
+                    ).addValue(
+                        aPersonNameValue()
+                            .withValue("John")
+                            .withVerified(true)
+                            .withFrom(new DateTime(2003, 5, 24, 0, 0, DateTimeZone.UTC))
+                            .withTo(new DateTime(2004, 1, 20, 0, 0, DateTimeZone.UTC))
+                            .build()
+                    ).addValue(
+                        aPersonNameValue()
+                            .withValue("Joe")
+                            .withVerified(true)
+                            .withFrom(new DateTime(2005, 5, 24, 0, 0, DateTimeZone.UTC))
+                            .withTo(getDateReplacement(replace180to100))
+                            .build()
+                    ).addValue(
+                        aPersonNameValue()
+                            .withValue("Simon")
+                            .withVerified(false)
+                            .withFrom(getDateReplacement(replace180to101))
+                            .withTo(getDateReplacement(replace180to150))
+                            .build()
+                    )
+                        .buildAsSurname(),
+                    aGender_1_1().withValue("Male").withVerified(false).withFrom(null).withTo(null).build(),
+                    aDate_1_1().addValue(
+                        aDateValue()
+                            .withValue("1980-05-24")
+                            .withVerified(true)
+                            .withFrom(null)
+                            .withTo(null)
+                            .build()).buildAsDateOfBirth(),
+                    anAddressAttribute().addAddress(
+                        anAddressAttributeValue()
+                            .addLines(asList("2323 George Street"))
+                            .withFrom(getDateReplacement(replaceYesterday))
+                            .withInternationalPostcode("GB1 5PP")
+                            .withPostcode("GB1 2PP")
+                            .withUprn("7D68E096-5510-B3844C0BA3FD")
+                            .withVerified(false)
+                            .withTo(null)
+                            .build())
+                        .buildCurrentAddress(),
+                    anAddressAttribute()
+                        .addAddress(
+                            anAddressAttributeValue()
+                                .addLines(asList("10 George Street"))
+                                .withFrom(new DateTime(2005, 5, 14, 0, 0, DateTimeZone.UTC))
+                                .withTo(new DateTime(2007, 5, 14, 0, 0, DateTimeZone.UTC))
+                                .withPostcode("GB1 2PF")
+                                .withInternationalPostcode("GB1 2PF")
+                                .withUprn("833F1187-9F33-A7E27B3F211E")
+                                .withVerified(true)
+                                .build()
+                        ).addAddress(
+                        anAddressAttributeValue()
+                            .addLines(asList("344 George Street"))
+                            .withFrom(new DateTime(2009, 5, 24, 0, 0, DateTimeZone.UTC))
+                            .withTo(getDateReplacement(replace405to100))
+                            .withPostcode("GB1 2PP")
+                            .withInternationalPostcode("GB1 2PP")
+                            .withUprn("7D68E096-5510-B3844C0BA3FD")
+                            .withVerified(true)
+                            .build()
+                    ).addAddress(
+                        anAddressAttributeValue()
+                            .addLines(asList("67676 George Street"))
+                            .withFrom(getDateReplacement(replace405to101))
+                            .withTo(getDateReplacement(replace405to200))
+                            .withPostcode("GB1 2PP")
+                            .withInternationalPostcode("GB1 3PP")
+                            .withUprn("7D68E096-5510-B3844C0BA3FD")
+                            .withVerified(false)
+                            .build()
+                    ).addAddress(
+                        anAddressAttributeValue()
+                            .addLines(asList("56563 George Street"))
+                            .withFrom(new DateTime(1980, 5, 24, 0, 0, DateTimeZone.UTC))
+                            .withTo(new DateTime(1987, 5, 24, 0, 0, DateTimeZone.UTC))
+                            .withPostcode("GB1 2PP")
+                            .withInternationalPostcode("GB1 3PP")
+                            .withUprn("7D68E096-5510-B3844C0BA3FD")
+                            .withVerified(false)
+                            .build()
+                    ).addAddress(
+                        anAddressAttributeValue()
+                            .addLines(asList("Flat , Alberta Court", "36 Harrods Road", "New Berkshire", "Berkshire", "Cambria", "Europe"))
+                            .withFrom(new DateTime(1987, 5, 24, 0, 0, DateTimeZone.UTC))
+                            .withTo(new DateTime(1989, 5, 24, 0, 0, DateTimeZone.UTC))
+                            .withPostcode(null)
+                            .withInternationalPostcode(null)
+                            .withUprn(null)
+                            .withVerified(false)
+                            .build()
+                    ).buildPreviousAddress()
+                ), false, REQUEST_ID)), REQUEST_ID, HUB_ENTITY_ID, PID))
+            .build();
+
+        Path path = Paths.get("verify-matching-service-test-tool/src/main/resources/LoA2-extensive-case.json");
+
+        assertThatRequestThatWillBeSentIsEquivalentToFile(attributeQuery, path);
+    }
+
+    @Test
+    public void shouldProducesUserAccountCreationJson() throws Exception {
+        AttributeQuery attributeQuery = AttributeQueryBuilder.anAttributeQuery()
+            .withId(REQUEST_ID)
+            .withAttributes(asList())
+            .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+            .withSubject(aSubjectWithAssertions(asList(
+                anAuthnStatementAssertion(IdaAuthnContext.LEVEL_1_AUTHN_CTX, REQUEST_ID),
+                aMatchingDatasetAssertion(asList(), false, REQUEST_ID)
+            ), REQUEST_ID, HUB_ENTITY_ID, PID))
+            .build();
+
+        makeAttributeQueryRequest(UNKNOWN_USER_URI, attributeQuery, signatureAlgorithmForHub, digestAlgorithmForHub, HUB_ENTITY_ID);
+
+        List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
+        assertThat(requests.size()).isEqualTo(1);
+
+        Path filePath = Paths.get("verify-matching-service-test-tool/src/main/resources/user-account-creation.json");
+
+        Map requestSent = objectMapper.readValue(requests.get(0).getBodyAsString(), Map.class);
+        Map requestExpected = objectMapper.readValue(readExpectedJson(filePath), Map.class);
+
+        assertThat(requestSent).isEqualToComparingFieldByFieldRecursively(requestExpected);
+    }
+
+    private void assertThatRequestThatWillBeSentIsEquivalentToFile(AttributeQuery attributeQuery, Path filePath) throws Exception {
+        makeAttributeQueryRequest(MATCHING_SERVICE_URI, attributeQuery, signatureAlgorithmForHub, digestAlgorithmForHub, HUB_ENTITY_ID);
+
+        List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
+
+        assertThat(requests.size()).isEqualTo(1);
+
+        Map requestSent = objectMapper.readValue(requests.get(0).getBodyAsString(), Map.class);
+        Map requestExpected = objectMapper.readValue(readExpectedJson(filePath), Map.class);
+
+        // These first two are not strictly necessary, as they are implied by the recursive field comparison,
+        // but they mean that we see a much more useful error message if field names are different.
+        assertThat(requestSent.keySet()).containsExactlyInAnyOrder(requestExpected.keySet().toArray());
+        assertThat(((Map)requestSent.get("matchingDataset")).keySet()).containsExactlyInAnyOrder(((Map)requestExpected.get("matchingDataset")).keySet().toArray());
+
+        assertThat(requestSent).isEqualToComparingFieldByFieldRecursively(requestExpected);
+    }
+
+    private String readExpectedJson(Path filePath) throws Exception {
+        return makeDateReplacements(new String(Files.readAllBytes(filePath)));
+    }
+
+    private String makeDateReplacements(String input) {
+        return input.replace("%yesterdayDate%", getDateReplacement(replaceYesterday).toString())
+            .replace("%within405days-100days%", getDateReplacement(replace405to100).toString())
+            .replace("%within405days-101days%", getDateReplacement(replace405to101).toString())
+            .replace("%within405days-200days%", getDateReplacement(replace405to200).toString())
+            .replace("%within180days-100days%", getDateReplacement(replace180to100).toString())
+            .replace("%within180days-101days%", getDateReplacement(replace180to101).toString())
+            .replace("%within180days-150days%", getDateReplacement(replace180to150).toString());
+    }
+
+    private DateTime getDateReplacement(Integer daysToSubtract) {
+        return new DateTime(DateTimeZone.UTC)
+            .withTime(0, 0, 0, 0)
+            .minusDays(daysToSubtract);
+    }
+}

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/mappers/MatchingDatasetToMatchingDatasetDtoMapperTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/mappers/MatchingDatasetToMatchingDatasetDtoMapperTest.java
@@ -109,7 +109,7 @@ public class MatchingDatasetToMatchingDatasetDtoMapperTest {
     }
 
     @Test
-    public void map_shouldCombineCurrentAndPreviousAddressesFromAMatchingDatasetToSingleAddressField(){
+    public void map_shouldCombineCurrentAndPreviousAddressesFromAMatchingDatasetToSingleAddressField() {
         String currentAddressLine = "line-1";
         String previousAddressLine = "previousAddressLine";
         List<Address> currentAddress = asList(new AddressFactory().create(asList(currentAddressLine), "post-code", "international-postcode", "uprn", DateTime.parse("1999-03-15"), DateTime.parse("2000-02-09"), true));
@@ -130,6 +130,30 @@ public class MatchingDatasetToMatchingDatasetDtoMapperTest {
         }
         assertThat(addressLines).contains(currentAddressLine);
         assertThat(addressLines).contains(previousAddressLine);
+    }
+
+    @Test
+    public void map_shouldPutCurrentAddressBeforePreviousAddressesWhenMappingToASingleAddressField() {
+        String currentAddressLine = "line-1";
+        String previousAddressLine = "previousAddressLine";
+        List<Address> currentAddress = asList(new AddressFactory().create(asList(currentAddressLine), "post-code", "international-postcode", "uprn", DateTime.parse("1999-03-15"), DateTime.parse("2000-02-09"), true));
+        List<Address> previousAddress = asList(new AddressFactory().create(asList(previousAddressLine), "post-code", "international-postcode", "uprn", DateTime.parse("1999-03-15"), DateTime.parse("2000-02-09"), true));
+        MatchingDataset matchingDataset = aMatchingDataset()
+            .withPreviousAddresses(previousAddress)
+            .withCurrentAddresses(currentAddress)
+            .build();
+
+        MatchingDatasetDto matchingDatasetDto = matchingDatasetToMatchingDatasetDtoMapper.map(matchingDataset);
+
+        List<AddressDto> addresses = matchingDatasetDto.getAddresses();
+        assertThat(addresses).hasSize(2);
+
+        List<String> addressLines = new ArrayList<>();
+        for(AddressDto addressDto : addresses){
+            addressLines.add(addressDto.getLines().get(0));
+        }
+        assertThat(addressLines.get(0)).isEqualTo(currentAddressLine);
+        assertThat(addressLines.get(1)).isEqualTo(previousAddressLine);
     }
 
     @Test

--- a/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/LevelOfAssuranceOneScenario.java
+++ b/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/LevelOfAssuranceOneScenario.java
@@ -35,9 +35,9 @@ public class LevelOfAssuranceOneScenario extends ScenarioBase {
     public void runForComplexCase() {
         String jsonString = fileUtils.readFromResources("LoA1-extensive-case.json")
             .replace("%yesterdayDate%", Instant.now().minus(1, DAYS).toString())
-            .replace("%within405days-100days%", Instant.now().minus(405-100, DAYS).toString())
-            .replace("%within405days-101days%", Instant.now().minus(405-101, DAYS).toString())
-            .replace("%within405days-200days%", Instant.now().minus(405-200, DAYS).toString());
+            .replace("%within405days-100days%", Instant.now().minus(100, DAYS).toString())
+            .replace("%within405days-101days%", Instant.now().minus(150, DAYS).toString())
+            .replace("%within405days-200days%", Instant.now().minus(400, DAYS).toString());
 
         Response response = client.target(configuration.getLocalMatchingServiceMatchUrl())
             .request(APPLICATION_JSON)

--- a/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/LevelOfAssuranceTwoScenario.java
+++ b/verify-matching-service-test-tool/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/LevelOfAssuranceTwoScenario.java
@@ -35,12 +35,12 @@ public class LevelOfAssuranceTwoScenario extends ScenarioBase {
     public void runForComplexCase() {
         String jsonString = fileUtils.readFromResources("LoA2-extensive-case.json")
             .replace("%yesterdayDate%", Instant.now().minus(1, DAYS).toString())
-            .replace("%within405days-100days%", Instant.now().minus(405-100, DAYS).toString())
-            .replace("%within405days-101days%", Instant.now().minus(405-101, DAYS).toString())
-            .replace("%within405days-200days%", Instant.now().minus(405-200, DAYS).toString())
-            .replace("%within180days-100days%", Instant.now().minus(105-100, DAYS).toString())
-            .replace("%within180days-101days%", Instant.now().minus(105-101, DAYS).toString())
-            .replace("%within180days-150days%", Instant.now().minus(105-150, DAYS).toString());
+            .replace("%within405days-100days%", Instant.now().minus(100, DAYS).toString())
+            .replace("%within405days-101days%", Instant.now().minus(150, DAYS).toString())
+            .replace("%within405days-200days%", Instant.now().minus(400, DAYS).toString())
+            .replace("%within180days-100days%", Instant.now().minus(100, DAYS).toString())
+            .replace("%within180days-101days%", Instant.now().minus(140, DAYS).toString())
+            .replace("%within180days-150days%", Instant.now().minus(160, DAYS).toString());
 
         Response response = client.target(configuration.getLocalMatchingServiceMatchUrl())
             .request(APPLICATION_JSON)

--- a/verify-matching-service-test-tool/src/main/resources/LoA1-extensive-case.json
+++ b/verify-matching-service-test-tool/src/main/resources/LoA1-extensive-case.json
@@ -1,9 +1,19 @@
 {
-  "hashedPid": "8a5db0ad424efe4e09622cc4a876cc4c338558384752b483ff69dda4dca1ef04",
+  "hashedPid": "8fbfdd035a92daf890673d9ff8f50def3aad66ea42026c581bd73735250ba706",
   "levelOfAssurance": "LEVEL_1",
   "matchId": "default-match-id",
   "matchingDataset": {
     "addresses": [
+      {
+        "fromDate": "%yesterdayDate%",
+        "internationalPostCode": "GB1 5PP",
+        "lines": [
+          "2323 George Street"
+        ],
+        "postCode": "GB1 2PP",
+        "uprn": "7D68E096-5510-B3844C0BA3FD",
+        "verified": false
+      },
       {
         "fromDate": "2005-05-14T00:00:00.000Z",
         "internationalPostCode": "GB1 2PF",
@@ -25,16 +35,6 @@
         "toDate": "%within405days-100days%",
         "uprn": "7D68E096-5510-B3844C0BA3FD",
         "verified": true
-      },
-      {
-        "fromDate": "%yesterdayDate%",
-        "internationalPostCode": "GB1 5PP",
-        "lines": [
-          "2323 George Street"
-        ],
-        "postCode": "GB1 2PP",
-        "uprn": "7D68E096-5510-B3844C0BA3FD",
-        "verified": false
       },
       {
         "fromDate": "%within405days-101days%",

--- a/verify-matching-service-test-tool/src/main/resources/LoA1-simple-case.json
+++ b/verify-matching-service-test-tool/src/main/resources/LoA1-simple-case.json
@@ -1,5 +1,5 @@
   {
-    "hashedPid": "8a5db0ad424efe4e09622cc4a876cc4c338558384752b483ff69dda4dca1ef04",
+    "hashedPid": "8fbfdd035a92daf890673d9ff8f50def3aad66ea42026c581bd73735250ba706",
     "levelOfAssurance": "LEVEL_1",
     "matchId": "default-match-id",
     "matchingDataset": {

--- a/verify-matching-service-test-tool/src/main/resources/LoA2-extensive-case.json
+++ b/verify-matching-service-test-tool/src/main/resources/LoA2-extensive-case.json
@@ -1,9 +1,19 @@
 {
-  "hashedPid": "8a5db0ad424efe4e09622cc4a876cc4c338558384752b483ff69dda4dca1ef04",
+  "hashedPid": "f8b5be711023fb45e7a13f323f1667767b0a7ef0584aec9550047655d8ce441b",
   "levelOfAssurance": "LEVEL_2",
   "matchId": "default-match-id",
   "matchingDataset": {
     "addresses": [
+      {
+        "fromDate": "%yesterdayDate%",
+        "internationalPostCode": "GB1 5PP",
+        "lines": [
+          "2323 George Street"
+        ],
+        "postCode": "GB1 2PP",
+        "uprn": "7D68E096-5510-B3844C0BA3FD",
+        "verified": false
+      },
       {
         "fromDate": "2005-05-14T00:00:00.000Z",
         "internationalPostCode": "GB1 2PF",
@@ -25,16 +35,6 @@
         "toDate": "%within405days-100days%",
         "uprn": "7D68E096-5510-B3844C0BA3FD",
         "verified": true
-      },
-      {
-        "fromDate": "%yesterdayDate%",
-        "internationalPostCode": "GB1 5PP",
-        "lines": [
-          "2323 George Street"
-        ],
-        "postCode": "GB1 2PP",
-        "uprn": "7D68E096-5510-B3844C0BA3FD",
-        "verified": false
       },
       {
         "fromDate": "%within405days-101days%",

--- a/verify-matching-service-test-tool/src/main/resources/LoA2-simple-case.json
+++ b/verify-matching-service-test-tool/src/main/resources/LoA2-simple-case.json
@@ -1,5 +1,5 @@
 {
-  "hashedPid": "8a5db0ad424efe4e09622cc4a876cc4c338558384752b483ff69dda4dca1ef04",
+  "hashedPid": "f8b5be711023fb45e7a13f323f1667767b0a7ef0584aec9550047655d8ce441b",
   "levelOfAssurance": "LEVEL_2",
   "matchId": "default-match-id",
   "matchingDataset": {

--- a/verify-matching-service-test-tool/src/main/resources/simple-case-excluding-optional-address-fields.json
+++ b/verify-matching-service-test-tool/src/main/resources/simple-case-excluding-optional-address-fields.json
@@ -1,5 +1,5 @@
 {
-  "hashedPid": "8a5db0ad424efe4e09622cc4a876cc4c338558384752b483ff69dda4dca1ef04",
+  "hashedPid": "f8b5be711023fb45e7a13f323f1667767b0a7ef0584aec9550047655d8ce441b",
   "levelOfAssurance": "LEVEL_2",
   "matchId": "default-match-id",
   "matchingDataset": {

--- a/verify-matching-service-test-tool/src/main/resources/user-account-creation.json
+++ b/verify-matching-service-test-tool/src/main/resources/user-account-creation.json
@@ -1,4 +1,4 @@
 {
-  "hashedPid": "sample-pid",
+  "hashedPid": "8fbfdd035a92daf890673d9ff8f50def3aad66ea42026c581bd73735250ba706",
   "levelOfAssurance": "LEVEL_1"
 }


### PR DESCRIPTION
…json

Should ensure that the json interface the test tool uses stays in sync
with the matching service adapter.
Tests that the json used in each of the default tests in the resources
folder of the test tool can be produced by the matching service adapter.
N.B. Does not ensure that the schema which validates user supplied test
cases remains up to date.

Authors: @rachaelbooth