### PR TITLE
EID-326: Update MSA to use hub truststore for eIDAS flow

### DIFF
--- a/src/integration-test/java/uk/gov/ida/integrationtest/helpers/MatchingServiceAdapterAppRule.java
+++ b/src/integration-test/java/uk/gov/ida/integrationtest/helpers/MatchingServiceAdapterAppRule.java
@@ -82,7 +82,6 @@ public class MatchingServiceAdapterAppRule extends DropwizardAppRule<MatchingSer
         metadataTrustStore.delete();
         countryMetadataTrustStore.delete();
         clientTrustStore.delete();
-
         super.after();
     }
 
@@ -110,30 +109,29 @@ public class MatchingServiceAdapterAppRule extends DropwizardAppRule<MatchingSer
 
         if (isCountryEnabled) {
             List<ConfigOverride> countryOverrides = Stream.of(
-                    ConfigOverride.config("returnStackTraceInResponse", "true"),  // Until eiDAS happy-path through MSA is complete (EID-270)
-                    ConfigOverride.config("country.hubConnectorEntityId", HUB_ENTITY_ID),
+                ConfigOverride.config("returnStackTraceInResponse", "true"),  // Until eiDAS happy-path through MSA is complete (EID-270)
+                ConfigOverride.config("country.hubConnectorEntityId", HUB_ENTITY_ID),
 
-                    ConfigOverride.config("country.metadata.uri", "http://localhost:" + countryMetadataServer.getPort() + COUNTRY_METADATA_PATH),
-                    ConfigOverride.config("country.metadata.trustStore.path", countryMetadataTrustStore.getAbsolutePath()),
-                    ConfigOverride.config("country.metadata.trustStore.password", countryMetadataTrustStore.getPassword()),
-                    ConfigOverride.config("country.metadata.minRefreshDelay", "60000"),
-                    ConfigOverride.config("country.metadata.maxRefreshDelay", "600000"),
-                    ConfigOverride.config("country.metadata.expectedEntityId", "http://stub_idp.acme.org/stub-idp-one/SSO/POST"),
-                    ConfigOverride.config("country.metadata.jerseyClientName", "country-metadata-client"),
+                ConfigOverride.config("country.metadata.uri", "http://localhost:" + countryMetadataServer.getPort() + COUNTRY_METADATA_PATH),
+                ConfigOverride.config("country.metadata.trustStore.path", countryMetadataTrustStore.getAbsolutePath()),
+                ConfigOverride.config("country.metadata.trustStore.password", countryMetadataTrustStore.getPassword()),
+                ConfigOverride.config("country.metadata.minRefreshDelay", "60000"),
+                ConfigOverride.config("country.metadata.maxRefreshDelay", "600000"),
+                ConfigOverride.config("country.metadata.expectedEntityId", "http://stub_idp.acme.org/stub-idp-one/SSO/POST"),
+                ConfigOverride.config("country.metadata.jerseyClientName", "country-metadata-client"),
 
-                    ConfigOverride.config("country.metadata.client.timeout", "2s"),
-                    ConfigOverride.config("country.metadata.client.timeToLive", "10m"),
-                    ConfigOverride.config("country.metadata.client.cookiesEnabled", "false"),
-                    ConfigOverride.config("country.metadata.client.connectionTimeout", "1s"),
-                    ConfigOverride.config("country.metadata.client.retries", "3"),
-                    ConfigOverride.config("country.metadata.client.keepAlive", "60s"),
-                    ConfigOverride.config("country.metadata.client.chunkedEncodingEnabled", "false"),
-                    ConfigOverride.config("country.metadata.client.validateAfterInactivityPeriod", "5s"),
+                ConfigOverride.config("country.metadata.client.timeout", "2s"),
+                ConfigOverride.config("country.metadata.client.timeToLive", "10m"),
+                ConfigOverride.config("country.metadata.client.cookiesEnabled", "false"),
+                ConfigOverride.config("country.metadata.client.connectionTimeout", "1s"),
+                ConfigOverride.config("country.metadata.client.retries", "3"),
+                ConfigOverride.config("country.metadata.client.keepAlive", "60s"),
+                ConfigOverride.config("country.metadata.client.chunkedEncodingEnabled", "false"),
+                ConfigOverride.config("country.metadata.client.validateAfterInactivityPeriod", "5s"),
 
-                    ConfigOverride.config("country.metadata.client.tls.protocol", "TLSv1.2"),
-                    ConfigOverride.config("country.metadata.client.tls.verifyHostname", "false"),
-                    ConfigOverride.config("country.metadata.client.tls.trustSelfSignedCertificates", "true")
-
+                ConfigOverride.config("country.metadata.client.tls.protocol", "TLSv1.2"),
+                ConfigOverride.config("country.metadata.client.tls.verifyHostname", "false"),
+                ConfigOverride.config("country.metadata.client.tls.trustSelfSignedCertificates", "true")
             ).collect(Collectors.toList());
             overrides.addAll(countryOverrides);
         }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -157,38 +157,18 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    @Named("VerifyCertificateValidator")
     public CertificateValidator getCertificateValidator(
         X509CertificateFactory x509CertificateFactory,
-        @Named("VerifyFixedCertificateChainValidator") FixedCertificateChainValidator fixedCertificateChainValidator) {
+        FixedCertificateChainValidator fixedCertificateChainValidator) {
         return new CertificateValidator(x509CertificateFactory, fixedCertificateChainValidator);
     }
 
     @Provides
     @Singleton
-    @Named("CountryCertificateValidator")
-    public Optional<CertificateValidator> getCountryCertificateValidator(
-        X509CertificateFactory x509CertificateFactory,
-        @Named("CountryFixedCertificateChainValidator") Optional<FixedCertificateChainValidator> fixedCertificateChainValidator) {
-        return fixedCertificateChainValidator.map(certificateChainValidator -> new CertificateValidator(x509CertificateFactory, certificateChainValidator));
-    }
-
-    @Provides
-    @Singleton
-    @Named("VerifyFixedCertificateChainValidator")
     public FixedCertificateChainValidator getFixedChainCertificateValidator(
-        @Named("VerifyTrustStore") KeyStore keyStore,
+        KeyStore keyStore,
         CertificateChainValidator certificateChainValidator) {
         return new FixedCertificateChainValidator(keyStore, certificateChainValidator);
-    }
-
-    @Provides
-    @Singleton
-    @Named("CountryFixedCertificateChainValidator")
-    public Optional<FixedCertificateChainValidator> getCountryFixedChainCertificateValidator(
-        @Named("CountryTrustStore") Optional<KeyStore> CountryTrustStore,
-        CertificateChainValidator certificateChainValidator) {
-        return CountryTrustStore.map(keyStore -> new FixedCertificateChainValidator(keyStore, certificateChainValidator));
     }
 
     @Provides
@@ -199,10 +179,9 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    @Named("VerifyCertificateChainEvaluableCriterion")
     public CertificateChainEvaluableCriterion getCertificateChainEvaluableCriterion(
         CertificateChainValidator certificateChainValidator,
-        @Named("VerifyTrustStore") KeyStore keyStore) {
+        KeyStore keyStore) {
         return new CertificateChainEvaluableCriterion(certificateChainValidator, keyStore);
     }
 
@@ -214,7 +193,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public MetadataCertificatesRepository getMetadataCertificateRepository(@Named(VERIFY_METADATA_RESOLVER) MetadataResolver metadataResolver, @Named("VerifyCertificateValidator") CertificateValidator certificateValidator) {
+    public MetadataCertificatesRepository getMetadataCertificateRepository(@Named(VERIFY_METADATA_RESOLVER) MetadataResolver metadataResolver, CertificateValidator certificateValidator) {
         return new MetadataCertificatesRepository(metadataResolver, certificateValidator, new CertificateExtractor());
     }
 
@@ -228,22 +207,13 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    @Named("VerifyTrustStoreConfiguration")
     public TrustStoreConfiguration getHubTrustStoreConfiguration(MatchingServiceAdapterConfiguration configuration) {
         return configuration.getHubTrustStoreConfiguration();
     }
 
     @Provides
     @Singleton
-    @Named("CountryTrustStore")
-    public Optional<KeyStore> getCountryTrustStoreConfiguration(MatchingServiceAdapterConfiguration configuration) {
-        return Optional.of(configuration.getHubTrustStoreConfiguration().getTrustStore());
-    }
-
-    @Provides
-    @Singleton
-    @Named("VerifyTrustStore")
-    public KeyStore getVerifyKeyStore(@Named("VerifyTrustStoreConfiguration") TrustStoreConfiguration trustStoreConfiguration) {
+    public KeyStore getVerifyKeyStore(TrustStoreConfiguration trustStoreConfiguration) {
         return trustStoreConfiguration.getTrustStore();
     }
 
@@ -267,15 +237,15 @@ class MatchingServiceAdapterModule extends AbstractModule {
             .collect(Collectors.toList());
 
         return new CertificateStore(
-                publicEncryptionCertificates,
-                publicSigningCertificates);
+            publicEncryptionCertificates,
+            publicSigningCertificates);
     }
 
     private Certificate cert(String keyName, String cert, Certificate.KeyUse keyUse) {
         return new Certificate(
-                keyName,
-                cert.replace("-----BEGIN CERTIFICATE-----", "").replace("-----END CERTIFICATE-----", "").replace(" ", ""),
-                keyUse);
+            keyName,
+            cert.replace("-----BEGIN CERTIFICATE-----", "").replace("-----END CERTIFICATE-----", "").replace(" ", ""),
+            keyUse);
     }
 
     @Provides
@@ -284,10 +254,10 @@ class MatchingServiceAdapterModule extends AbstractModule {
         Injector injector
     ) {
         return new MsaTransformersFactory().getHealthcheckResponseFromMatchingServiceToElementTransformer(
-                injector.getInstance(EncryptionKeyStore.class),
-                injector.getInstance(IdaKeyStore.class),
-                injector.getInstance(EntityToEncryptForLocator.class),
-                injector.getInstance(MatchingServiceAdapterConfiguration.class)
+            injector.getInstance(EncryptionKeyStore.class),
+            injector.getInstance(IdaKeyStore.class),
+            injector.getInstance(EntityToEncryptForLocator.class),
+            injector.getInstance(MatchingServiceAdapterConfiguration.class)
         );
     }
 
@@ -297,10 +267,10 @@ class MatchingServiceAdapterModule extends AbstractModule {
         Injector injector
     ) {
         return new MsaTransformersFactory().getOutboundResponseFromMatchingServiceToElementTransformer(
-                injector.getInstance(EncryptionKeyStore.class),
-                injector.getInstance(IdaKeyStore.class),
-                injector.getInstance(EntityToEncryptForLocator.class),
-                injector.getInstance(MatchingServiceAdapterConfiguration.class)
+            injector.getInstance(EncryptionKeyStore.class),
+            injector.getInstance(IdaKeyStore.class),
+            injector.getInstance(EntityToEncryptForLocator.class),
+            injector.getInstance(MatchingServiceAdapterConfiguration.class)
         );
     }
 
@@ -310,10 +280,10 @@ class MatchingServiceAdapterModule extends AbstractModule {
         Injector injector
     ) {
         return new MsaTransformersFactory().getOutboundResponseFromUnknownUserCreationServiceToElementTransformer(
-                injector.getInstance(EncryptionKeyStore.class),
-                injector.getInstance(IdaKeyStore.class),
-                injector.getInstance(EntityToEncryptForLocator.class),
-                injector.getInstance(MatchingServiceAdapterConfiguration.class)
+            injector.getInstance(EncryptionKeyStore.class),
+            injector.getInstance(IdaKeyStore.class),
+            injector.getInstance(EntityToEncryptForLocator.class),
+            injector.getInstance(MatchingServiceAdapterConfiguration.class)
         );
     }
 
@@ -329,26 +299,25 @@ class MatchingServiceAdapterModule extends AbstractModule {
         @Named(VERIFY_METADATA_RESOLVER) MetadataResolver metadataResolver,
         IdaKeyStore keyStore,
         MatchingServiceAdapterConfiguration matchingServiceAdapterConfiguration,
-        @Named("VerifyCertificateChainEvaluableCriterion") CertificateChainEvaluableCriterion certificateChainEvaluableCriterion,
+        CertificateChainEvaluableCriterion certificateChainEvaluableCriterion,
         @Named("HubEntityId") String hubEntityId) throws ComponentInitializationException {
         return new MsaTransformersFactory().getVerifyAttributeQueryToInboundMatchingServiceRequestTransformer(
-                metadataResolver,
-                keyStore,
-                matchingServiceAdapterConfiguration,
-                hubEntityId,
-                certificateChainEvaluableCriterion);
+            metadataResolver,
+            keyStore,
+            matchingServiceAdapterConfiguration,
+            hubEntityId,
+            certificateChainEvaluableCriterion);
     }
 
     @Provides
     @Singleton
     private Function<AttributeQuery, InboundMatchingServiceRequest> getAttributeQueryToInboundMatchingServiceRequestTransformer(
-            @Named(COUNTRY_METADATA_RESOLVER) Optional<MetadataResolver> countryMetadataResolver,
-            @Named(VERIFY_METADATA_RESOLVER) MetadataResolver verifyMetadataResolver,
-            @Named("VerifyCertificateValidator") CertificateValidator verifyCertificateValidator,
-            @Named("CountryCertificateValidator") Optional<CertificateValidator> countryCertificateValidator,
-            X509CertificateFactory x509CertificateFactory,
-            IdaKeyStore eidasKeystore,
-            VerifyAttributeQueryToInboundMatchingServiceRequestTransformer verifyTransformer) throws ComponentInitializationException {
+        @Named(COUNTRY_METADATA_RESOLVER) Optional<MetadataResolver> countryMetadataResolver,
+        @Named(VERIFY_METADATA_RESOLVER) MetadataResolver verifyMetadataResolver,
+        CertificateValidator verifyCertificateValidator,
+        X509CertificateFactory x509CertificateFactory,
+        IdaKeyStore eidasKeystore,
+        VerifyAttributeQueryToInboundMatchingServiceRequestTransformer verifyTransformer) throws ComponentInitializationException {
 
         if (countryMetadataResolver.isPresent()) {
             EidasAttributesBasedAttributeQueryDiscriminator discriminator = new EidasAttributesBasedAttributeQueryDiscriminator(
@@ -362,7 +331,6 @@ class MatchingServiceAdapterModule extends AbstractModule {
                             verifyMetadataResolver,
                             countryMetadataResolver.get(),
                             verifyCertificateValidator,
-                            countryCertificateValidator.get(),
                             new CertificateExtractor(),
                             x509CertificateFactory,
                             new DateTimeComparator(Duration.ZERO),
@@ -444,5 +412,4 @@ class MatchingServiceAdapterModule extends AbstractModule {
         }
         return Optional.empty();
     }
-
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/CountryConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/CountryConfiguration.java
@@ -12,12 +12,21 @@ public class CountryConfiguration {
     @NotNull
     @Valid
     @JsonProperty
-    public String hubConnectorEntityId;
+    private String hubConnectorEntityId;
 
     @NotNull
     @Valid
     @JsonProperty
     private TrustStoreBackedMetadataConfiguration metadata;
+
+    private CountryConfiguration() { }
+
+    public CountryConfiguration(
+        final String hubConnectorEntityId,
+        final TrustStoreBackedMetadataConfiguration metadata) {
+        this.hubConnectorEntityId = hubConnectorEntityId;
+        this.metadata = metadata;
+    }
 
     public String getHubConnectorEntityId() {
         return hubConnectorEntityId;

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/EidasAttributeQueryValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/EidasAttributeQueryValidator.java
@@ -31,14 +31,14 @@ public class EidasAttributeQueryValidator extends CompositeValidator<AttributeQu
     public static final MessageImpl DEFAULT_INVALID_SIGNATURE_MESSAGE = globalMessage("invalid.signature", "Eidas Attribute Query's signature was invalid.");
     public static final String IDENTITY_ASSERTION = "Identity";
 
-    public EidasAttributeQueryValidator(MetadataResolver verifyMetadataResolver,
-                                        MetadataResolver countryMetadataResolver,
-                                        CertificateValidator verifyHubCertificateValidator,
-                                        CertificateValidator countryMetadataCertificateValidator,
-                                        CertificateExtractor certificateExtractor,
-                                        X509CertificateFactory x509CertificateFactory,
-                                        DateTimeComparator dateTimeComparator,
-                                        AssertionDecrypter assertionDecrypter) {
+
+    public EidasAttributeQueryValidator(final MetadataResolver verifyMetadataResolver,
+                                        final MetadataResolver countryMetadataResolver,
+                                        final CertificateValidator verifyCertificateValidator,
+                                        final CertificateExtractor certificateExtractor,
+                                        final X509CertificateFactory x509CertificateFactory,
+                                        final DateTimeComparator dateTimeComparator,
+                                        final AssertionDecrypter assertionDecrypter) {
         super(
             false,
             new CompositeValidator<>(
@@ -46,7 +46,7 @@ public class EidasAttributeQueryValidator extends CompositeValidator<AttributeQu
                 new IssuerValidator<>(DEFAULT_ISSUER_REQUIRED_MESSAGE, DEFAULT_ISSUER_EMPTY_MESSAGE, AttributeQuery::getIssuer),
                 new SamlDigitalSignatureValidator<>(
                     DEFAULT_INVALID_SIGNATURE_MESSAGE,
-                    attributeQuery -> new MetadataCertificatesRepository(verifyMetadataResolver, verifyHubCertificateValidator, certificateExtractor)
+                    attributeQuery -> new MetadataCertificatesRepository(verifyMetadataResolver, verifyCertificateValidator, certificateExtractor)
                         .getHubSigningCertificates(attributeQuery.getIssuer().getValue()).stream()
                         .map(Certificate::getCertificate)
                         .map(x509CertificateFactory::createCertificate)
@@ -63,7 +63,7 @@ public class EidasAttributeQueryValidator extends CompositeValidator<AttributeQu
                     aqr -> assertionDecrypter.decryptAssertions(() -> getEncryptedAssertions(aqr)).get(0),
                     new EidasAttributeQueryAssertionValidator(
                         countryMetadataResolver,
-                        countryMetadataCertificateValidator,
+                        verifyCertificateValidator,
                         certificateExtractor,
                         x509CertificateFactory,
                         dateTimeComparator,

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/configuration/CountryConfigurationTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/configuration/CountryConfigurationTest.java
@@ -1,0 +1,42 @@
+package uk.gov.ida.matchingserviceadapter.configuration;
+
+import io.dropwizard.client.JerseyClientConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.ida.saml.metadata.FileBackedTrustStoreConfiguration;
+import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CountryConfigurationTest {
+
+    private static final String HUB_CONNECTOR_ENTITY_ID = "hubConnectorEntityId";
+    private static final TrustStoreBackedMetadataConfiguration METADATA_CONFIGURATION = new TrustStoreBackedMetadataConfiguration(
+        URI.create("uri"),
+        10L,
+        100L,
+        "expectedEntityId",
+        new JerseyClientConfiguration(),
+        "jerseyClientName",
+        "hubFederationId",
+        new FileBackedTrustStoreConfiguration()
+    );
+    private CountryConfiguration countryConfiguration;
+
+    @Before
+    public void setUp() throws Exception {
+        countryConfiguration = new CountryConfiguration(HUB_CONNECTOR_ENTITY_ID, METADATA_CONFIGURATION);
+    }
+
+    @Test
+    public void getHubConnectorEntityId() throws Exception {
+        assertThat(countryConfiguration.getHubConnectorEntityId()).isEqualTo(HUB_CONNECTOR_ENTITY_ID);
+    }
+
+    @Test
+    public void getMetadata() throws Exception {
+        assertThat(countryConfiguration.getMetadata()).isEqualTo(METADATA_CONFIGURATION);
+    }
+}

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validators/EidasAttributeQueryValidatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validators/EidasAttributeQueryValidatorTest.java
@@ -63,9 +63,6 @@ public class EidasAttributeQueryValidatorTest {
     private CertificateValidator verifyCertificateValidator;
 
     @Mock
-    private CertificateValidator countryCertificateValidator;
-
-    @Mock
     private CertificateExtractor certificateExtractor;
 
     @Mock
@@ -83,7 +80,6 @@ public class EidasAttributeQueryValidatorTest {
             verifyMetadataResolver,
             countryMetadataResolver,
             verifyCertificateValidator,
-            countryCertificateValidator,
             certificateExtractor,
             x509CertificateFactory,
             new DateTimeComparator(Duration.ZERO),


### PR DESCRIPTION
MSA will use hub truststore to validate eIDAS SAML Attribute Query's signature and its assertion's signature fully.

Authors: @adityapahuja