### PR TITLE
bau: Fix issue with ./gradlew clean test

### DIFF
--- a/verify-matching-service-test-tool/build.gradle
+++ b/verify-matching-service-test-tool/build.gradle
@@ -65,27 +65,29 @@ distZip {
     }
 }
 
-task copyExamples(type: Copy) {
-    ['build/examples', 'out/examples'].each { dest ->
-        copy {
-            from projectDir.getPath() + "/examples"
-            into dest
+task copyExamples(dependsOn: assemble) {
+    doLast {
+        ['build', 'out'].each { dest ->
+            copy {
+                from 'examples'
+                into "${dest}/examples"
+            }
         }
     }
 }
 
-task copyConfiguration(type: Copy) {
-    ['build', 'out'].each { dest ->
-        copy {
-            from project.rootDir.getPath() + "/verify-matching-service-test-tool.yml"
-            into dest
+task copyConfiguration(dependsOn: assemble) {
+    doLast {
+        ['build', 'out'].each { dest ->
+            copy {
+                from 'verify-matching-service-test-tool.yml'
+                into dest
+            }
         }
     }
 }
 
-compileJava {
-    dependsOn copyExamples
-    dependsOn copyConfiguration
-}
+test { dependsOn copyExamples, copyConfiguration }
+run { dependsOn copyExamples, copyConfiguration }
 
 mainClassName = 'uk.gov.ida.verifymatchingservicetesttool.Application'


### PR DESCRIPTION
There was an issue with the way we'd set up our copy tasks where they
would run immediately, instead of as part of the task. This is due to
the confusing `doLast` stuff in the gradle DSL wherein code in the block
executes as soon as the gradle file is interpreted unless it's in some
special kind of task or a doLast block.

See https://docs.gradle.org/current/userguide/tutorial_using_tasks.html

When one ran gradle clean test the following was happening:

* As soon as the file was parsed, the `copy` command was running and
  copying the files into build.
* When the clean task ran it would remove the build directory.
* When the tests ran they'd fail, because their directory had been
  deleted.

By making the custom `copyExamples` and `copyConfiguration` tasks normal
tasks (i.e. not `type: Copy`), giving them `doLast` blocks and calling
`copy` inside the `doLast` we ensure that the copy operation happens
when the tasks run, not when the gradle file is parsed.

I've also made the tasks depend on `assemble` so that the build
directory they're copying into is guaranteed to exist. Finally, I've
made the two `copy` tasks a dependency of `test` and `run` so the files
will always be present when the application is run through gradle.

Authors: @richardtowers