### PR TITLE
EID-330: Reapply handling of EU users within the LMS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ def dependencyVersions = [
         saml_utils: "$opensaml-53",
         saml_test_utils:"$opensaml-34",
         saml_domain_objects: "$opensaml-40",
-        hub_saml: "$opensaml-98",
+        hub_saml: "$opensaml-100",
         dev_pki: '1.1.0-19'
 ]
 

--- a/src/integration-test/java/uk/gov/ida/integrationtest/CountryEnabledIntegrationTest.java
+++ b/src/integration-test/java/uk/gov/ida/integrationtest/CountryEnabledIntegrationTest.java
@@ -1,12 +1,15 @@
 package uk.gov.ida.integrationtest;
 
 import helpers.JerseyClientConfigurationBuilder;
+import httpstub.HttpStubRule;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import io.dropwizard.util.Duration;
 import org.apache.http.HttpStatus;
 import org.joda.time.DateTime;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -17,11 +20,14 @@ import org.opensaml.saml.saml2.core.Conditions;
 import org.opensaml.saml.saml2.core.impl.AudienceBuilder;
 import org.opensaml.saml.saml2.core.impl.AudienceRestrictionBuilder;
 import org.opensaml.saml.saml2.core.impl.ConditionsBuilder;
+import org.opensaml.xmlsec.algorithm.DigestAlgorithm;
+import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
+import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA256;
+import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA1;
 import org.opensaml.xmlsec.signature.Signature;
 import org.w3c.dom.Document;
 import uk.gov.ida.integrationtest.helpers.MatchingServiceAdapterAppRule;
 import uk.gov.ida.matchingserviceadapter.MatchingServiceAdapterConfiguration;
-import uk.gov.ida.matchingserviceadapter.domain.EidasLoa;
 import uk.gov.ida.matchingserviceadapter.rest.Urls;
 import uk.gov.ida.matchingserviceadapter.rest.soap.SoapMessageManager;
 import uk.gov.ida.saml.core.test.TestCredentialFactory;
@@ -38,13 +44,17 @@ import java.net.URI;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.opensaml.saml.saml2.core.StatusCode.RESPONDER;
+import static org.opensaml.saml.saml2.core.StatusCode.SUCCESS;
 import static uk.gov.ida.integrationtest.helpers.AssertionHelper.aSubjectWithEncryptedAssertions;
 import static uk.gov.ida.integrationtest.helpers.AssertionHelper.anEidasEncryptedAssertion;
 import static uk.gov.ida.integrationtest.helpers.AssertionHelper.anEidasEncryptedAssertionWithInvalidSignature;
-import static uk.gov.ida.matchingserviceadapter.saml.transformers.inbound.transformers.EidasAttributeQueryToInboundMatchingServiceRequestTransformer.TODO_MESSAGE;
+import static uk.gov.ida.integrationtest.helpers.RequestHelper.makeAttributeQueryRequest;
 import static uk.gov.ida.matchingserviceadapter.validators.EidasAttributeQueryAssertionValidator.generateInvalidSignatureMessage;
 import static uk.gov.ida.matchingserviceadapter.validators.EidasAttributeQueryValidator.DEFAULT_INVALID_SIGNATURE_MESSAGE;
 import static uk.gov.ida.matchingserviceadapter.validators.EidasAttributeQueryValidator.IDENTITY_ASSERTION;
+import static uk.gov.ida.saml.core.domain.SamlStatusCode.MATCH;
+import static uk.gov.ida.saml.core.domain.SamlStatusCode.NO_MATCH;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HEADLESS_RP_PRIVATE_SIGNING_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HEADLESS_RP_PUBLIC_SIGNING_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY;
@@ -52,96 +62,76 @@ import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_S
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PRIVATE_SIGNING_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PUBLIC_ENCRYPTION_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PUBLIC_SIGNING_CERT;
 import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_ENTITY_ID;
 import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_SECONDARY_ENTITY_ID;
 import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_IDP_ONE;
 import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
 import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anEidasAttributeStatement;
-import static uk.gov.ida.saml.core.test.builders.AuthnContextBuilder.anAuthnContext;
-import static uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder.anAuthnContextClassRef;
-import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anAuthnStatement;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anEidasAuthnStatement;
 import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
 import static uk.gov.ida.saml.core.test.builders.SignatureBuilder.aSignature;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder.aSubjectConfirmationData;
+import static uk.gov.ida.saml.core.test.matchers.SignableSAMLObjectBaseMatcher.signedBy;
 
 public class CountryEnabledIntegrationTest {
 
     private static final String REQUEST_ID = "a-request-id";
+    private static final String MATCHING_REQUEST_PATH = "/matching-request";
+    private static final SignatureAlgorithm SIGNATURE_ALGORITHM = new SignatureRSASHA1();
+    private static final DigestAlgorithm DIGEST_ALGORITHM = new DigestSHA256();
 
     private static Client client;
+    private static String msaMatchingUrl;
 
     @ClassRule
-    public static final DropwizardAppRule<MatchingServiceAdapterConfiguration> msaApplicationRule = new MatchingServiceAdapterAppRule(true);
-    public static String MSA_MATCHING_URL;
+    public static final HttpStubRule localMatchingService = new HttpStubRule();
+
+    @ClassRule
+    public static final DropwizardAppRule<MatchingServiceAdapterConfiguration> msaApplicationRule = new MatchingServiceAdapterAppRule(true,
+        ConfigOverride.config("localMatchingService.matchUrl", "http://localhost:" + localMatchingService.getPort() + MATCHING_REQUEST_PATH));
 
     @BeforeClass
     public static void beforeClass() {
         JerseyClientConfiguration jerseyClientConfiguration = JerseyClientConfigurationBuilder.aJerseyClientConfiguration().withTimeout(Duration.seconds(10)).build();
         client = new JerseyClientBuilder(msaApplicationRule.getEnvironment()).using(jerseyClientConfiguration).build(CountryEnabledIntegrationTest.class.getSimpleName());
-        MSA_MATCHING_URL = "http://localhost:" + msaApplicationRule.getLocalPort() + Urls.MatchingServiceAdapterUrls.MATCHING_SERVICE_ROOT
+        msaMatchingUrl = "http://localhost:" + msaApplicationRule.getLocalPort() + Urls.MatchingServiceAdapterUrls.MATCHING_SERVICE_ROOT
             + Urls.MatchingServiceAdapterUrls.MATCHING_SERVICE_MATCH_REQUEST_PATH;
+    }
+
+    @Before
+    public void setup() throws Exception {
+        localMatchingService.reset();
+        localMatchingService.register(MATCHING_REQUEST_PATH, 200, "application/json", "{\"result\": \"match\"}");
     }
 
     @Test
     public void shouldFetchCountryMetadataWhenCountryConfigExists() {
-
         assertThat(msaApplicationRule.getEnvironment().healthChecks().getNames()).contains("CountryMetadataHealthCheck");
     }
 
     @Test
-    public void shouldProcessEidasAttributeQueryRequestSuccessfully() {
-        String issuerId = HUB_ENTITY_ID;
-        AttributeQuery attributeQuery = AttributeQueryBuilder.anAttributeQuery()
-                .withId(REQUEST_ID)
-                .withIssuer(anIssuer().withIssuerId(issuerId).build())
-            .withSubject(
-                    aSubjectWithEncryptedAssertions(
-                        singletonList(
-                            anAssertion()
-                                .withIssuer(
-                                    anIssuer()
-                                        .withIssuerId(STUB_IDP_ONE)
-                                        .build())
-                                .addAttributeStatement(anEidasAttributeStatement().build())
-                                .addAuthnStatement(
-                                    anAuthnStatement()
-                                    .withAuthnContext(
-                                        anAuthnContext()
-                                            .withAuthnContextClassRef(
-                                                anAuthnContextClassRef()
-                                                .withAuthnContextClasRefValue(EidasLoa.HIGH.getValueUri())
-                                                .build()
-                                            )
-                                        .build()
+    public void shouldProcessMatchedEidasAttributeQueryRequestSuccessfully() {
+        org.opensaml.saml.saml2.core.Response response = makeAttributeQueryRequest(msaMatchingUrl, aValidAttributeQuery(), SIGNATURE_ALGORITHM, DIGEST_ALGORITHM, HUB_ENTITY_ID);
 
-                                    )
-                                        .build())
-                                .withSignature(aValidSignature())
-                                .withConditions(aConditions())
-                                .buildWithEncrypterCredential(
-                                    new TestCredentialFactory(
-                                        TEST_RP_MS_PUBLIC_ENCRYPTION_CERT,
-                                        TEST_RP_MS_PRIVATE_ENCRYPTION_KEY
-                                    ).getEncryptingCredential()
-                                )
-                        ),
-                        REQUEST_ID, HUB_ENTITY_ID)
-                )
-                .withSignature(
-                    aSignature()
-                        .withSigningCredential(
-                            new TestCredentialFactory(
-                                HUB_TEST_PUBLIC_SIGNING_CERT,
-                                HUB_TEST_PRIVATE_SIGNING_KEY
-                            ).getSigningCredential()
-                        ).build()
-                )
-                .build();
+        assertThat(response.getStatus().getStatusCode().getValue()).isEqualTo(SUCCESS);
+        assertThat(response.getStatus().getStatusCode().getStatusCode().getValue()).isEqualTo(MATCH);
+        assertThat(response).is(signedBy(TEST_RP_MS_PUBLIC_SIGNING_CERT, TEST_RP_MS_PRIVATE_SIGNING_KEY));
+    }
 
-        Response response = postResponse(MSA_MATCHING_URL, attributeQuery);
+    @Test
+    public void shouldProcessUnmatchedEidasAttributeQueryRequestSuccessfully() throws Exception {
+        localMatchingService.reset();
+        localMatchingService.register(MATCHING_REQUEST_PATH, 200, "application/json", "{\"result\": \"no-match\"}");
+        org.opensaml.saml.saml2.core.Response response = makeAttributeQueryRequest(msaMatchingUrl, aValidAttributeQuery(), SIGNATURE_ALGORITHM, DIGEST_ALGORITHM, HUB_ENTITY_ID);
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        assertThat(response.readEntity(String.class)).contains(TODO_MESSAGE);
+        assertThat(response.getStatus().getStatusCode().getValue()).isEqualTo(RESPONDER);
+        assertThat(response.getStatus().getStatusCode().getStatusCode().getValue()).isEqualTo(NO_MATCH);
+        assertThat(response).is(signedBy(TEST_RP_MS_PUBLIC_SIGNING_CERT, TEST_RP_MS_PRIVATE_SIGNING_KEY));
     }
 
     @Test
@@ -165,7 +155,7 @@ public class CountryEnabledIntegrationTest {
             )
             .build();
 
-        Response response = postResponse(MSA_MATCHING_URL, attributeQuery);
+        Response response = postResponse(msaMatchingUrl, attributeQuery);
 
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_INTERNAL_SERVER_ERROR);
         assertThat(response.readEntity(String.class)).contains(DEFAULT_INVALID_SIGNATURE_MESSAGE.getRenderedMessage());
@@ -181,21 +171,51 @@ public class CountryEnabledIntegrationTest {
                 aSubjectWithEncryptedAssertions(
                     singletonList(anEidasEncryptedAssertionWithInvalidSignature()), REQUEST_ID, HUB_ENTITY_ID)
             )
-            .withSignature(
-                aSignature()
-                    .withSigningCredential(
-                        new TestCredentialFactory(
-                            HUB_TEST_PUBLIC_SIGNING_CERT,
-                            HUB_TEST_PRIVATE_SIGNING_KEY
-                        ).getSigningCredential()
-                    ).build()
-            )
+            .withSignature(aHubSignature())
             .build();
 
-        Response response = postResponse(MSA_MATCHING_URL, attributeQuery);
+        Response response = postResponse(msaMatchingUrl, attributeQuery);
 
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_INTERNAL_SERVER_ERROR);
         assertThat(response.readEntity(String.class)).contains(generateInvalidSignatureMessage(IDENTITY_ASSERTION).getRenderedMessage());
+    }
+
+    private AttributeQuery aValidAttributeQuery() {
+        return AttributeQueryBuilder.anAttributeQuery()
+            .withId(REQUEST_ID)
+            .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+            .withSubject(
+                aSubjectWithEncryptedAssertions(
+                    singletonList(
+                        anAssertion()
+                            .withSubject(
+                                aSubject().withSubjectConfirmation(
+                                    aSubjectConfirmation().withSubjectConfirmationData(
+                                        aSubjectConfirmationData()
+                                            .withInResponseTo(REQUEST_ID)
+                                            .build())
+                                        .build())
+                                    .build()
+                            )
+                            .withIssuer(
+                                anIssuer()
+                                    .withIssuerId(STUB_IDP_ONE)
+                                    .build())
+                            .addAttributeStatement(anEidasAttributeStatement().build())
+                            .addAuthnStatement(anEidasAuthnStatement().build())
+                            .withSignature(anIdpSignature())
+                            .withConditions(aConditions())
+                            .buildWithEncrypterCredential(
+                                new TestCredentialFactory(
+                                    TEST_RP_MS_PUBLIC_ENCRYPTION_CERT,
+                                    TEST_RP_MS_PRIVATE_ENCRYPTION_KEY
+                                ).getEncryptingCredential()
+                            )
+                    ),
+                    REQUEST_ID, HUB_ENTITY_ID)
+            )
+            .withSignature(aHubSignature())
+            .build();
     }
 
     private Response postResponse(String url, AttributeQuery attributeQuery) {
@@ -204,12 +224,22 @@ public class CountryEnabledIntegrationTest {
 
         URI uri = UriBuilder.fromPath(url).build();
         return client
-                .target(uri.toASCIIString())
-                .request()
-                .post(Entity.entity(xmlString, MediaType.TEXT_XML));
+            .target(uri.toASCIIString())
+            .request()
+            .post(Entity.entity(xmlString, MediaType.TEXT_XML));
     }
 
-    private static Signature aValidSignature() {
+    private static Signature aHubSignature() {
+        return aSignature()
+            .withSigningCredential(
+                new TestCredentialFactory(
+                    HUB_TEST_PUBLIC_SIGNING_CERT,
+                    HUB_TEST_PRIVATE_SIGNING_KEY
+                ).getSigningCredential()
+            ).build();
+    }
+
+    private static Signature anIdpSignature() {
         return aSignature()
             .withSigningCredential(
                 new TestCredentialFactory(
@@ -223,12 +253,11 @@ public class CountryEnabledIntegrationTest {
         Conditions conditions = new ConditionsBuilder().buildObject();
         conditions.setNotBefore(DateTime.now());
         conditions.setNotOnOrAfter(DateTime.now().plusMinutes(10));
-        AudienceRestriction audienceRestriction= new AudienceRestrictionBuilder().buildObject();
+        AudienceRestriction audienceRestriction = new AudienceRestrictionBuilder().buildObject();
         Audience audience = new AudienceBuilder().buildObject();
         audience.setAudienceURI(HUB_SECONDARY_ENTITY_ID);
         audienceRestriction.getAudiences().add(audience);
         conditions.getAudienceRestrictions().add(audienceRestriction);
         return conditions;
     }
-
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -144,7 +144,12 @@ class MatchingServiceAdapterModule extends AbstractModule {
         bind(AdapterToMatchingServiceProxy.class).to(AdapterToMatchingServiceHttpProxy.class).in(Singleton.class);
         bind(ManifestReader.class).toInstance(new ManifestReader());
         bind(MatchingDatasetToMatchingDatasetDtoMapper.class).toInstance(new MatchingDatasetToMatchingDatasetDtoMapper());
-        bind(UserIdHashFactory.class).toInstance(new UserIdHashFactory());
+    }
+
+    @Provides
+    @Singleton
+    private UserIdHashFactory getUserIdHashFactory(MatchingServiceAdapterConfiguration configuration) {
+        return new UserIdHashFactory(configuration.getEntityId());
     }
 
     @Provides

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -66,6 +66,7 @@ import uk.gov.ida.matchingserviceadapter.saml.transformers.outbound.HealthCheckR
 import uk.gov.ida.matchingserviceadapter.saml.transformers.outbound.OutboundResponseFromMatchingService;
 import uk.gov.ida.matchingserviceadapter.saml.transformers.outbound.OutboundResponseFromUnknownUserCreationService;
 import uk.gov.ida.matchingserviceadapter.services.DelegatingMatchingService;
+import uk.gov.ida.matchingserviceadapter.services.EidasMatchingRequestToLMSRequestTransform;
 import uk.gov.ida.matchingserviceadapter.services.EidasMatchingService;
 import uk.gov.ida.matchingserviceadapter.services.HealthCheckMatchingService;
 import uk.gov.ida.matchingserviceadapter.services.MatchingService;
@@ -224,7 +225,8 @@ class MatchingServiceAdapterModule extends AbstractModule {
                     new DateTimeComparator(Duration.ZERO),
                     assertionDecrypter,
                     configuration.getCountry().getHubConnectorEntityId()
-                )
+                ),
+                new EidasMatchingRequestToLMSRequestTransform()
             ));
     }
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -44,8 +44,8 @@ import uk.gov.ida.matchingserviceadapter.mappers.DocumentToInboundMatchingServic
 import uk.gov.ida.matchingserviceadapter.mappers.InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper;
 import uk.gov.ida.matchingserviceadapter.mappers.MatchingDatasetToMatchingDatasetDtoMapper;
 import uk.gov.ida.matchingserviceadapter.mappers.MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper;
-import uk.gov.ida.matchingserviceadapter.proxies.AdapterToMatchingServiceHttpProxy;
-import uk.gov.ida.matchingserviceadapter.proxies.AdapterToMatchingServiceProxy;
+import uk.gov.ida.matchingserviceadapter.proxies.MatchingServiceProxy;
+import uk.gov.ida.matchingserviceadapter.proxies.MatchingServiceProxyImpl;
 import uk.gov.ida.matchingserviceadapter.repositories.CertificateExtractor;
 import uk.gov.ida.matchingserviceadapter.repositories.CertificateValidator;
 import uk.gov.ida.matchingserviceadapter.repositories.MatchingServiceAdapterMetadataRepository;
@@ -141,7 +141,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
         bind(EncryptionKeyStore.class).to(MetadataPublicKeyStore.class).in(Singleton.class);
         bind(PublicKeyInputStreamFactory.class).to(PublicKeyFileInputStreamFactory.class).in(Singleton.class);
         bind(AssertionLifetimeConfiguration.class).to(MatchingServiceAdapterConfiguration.class).in(Singleton.class);
-        bind(AdapterToMatchingServiceProxy.class).to(AdapterToMatchingServiceHttpProxy.class).in(Singleton.class);
+        bind(MatchingServiceProxy.class).to(MatchingServiceProxyImpl.class).in(Singleton.class);
         bind(ManifestReader.class).toInstance(new ManifestReader());
         bind(MatchingDatasetToMatchingDatasetDtoMapper.class).toInstance(new MatchingDatasetToMatchingDatasetDtoMapper());
     }
@@ -180,7 +180,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
         HealthCheckMatchingService healthCheckMatchingService,
         VerifyMatchingService verifyMatchingService,
         Optional<EidasMatchingService> eidasMatchingService,
-            @Named(COUNTRY_METADATA_RESOLVER) Optional<MetadataResolver> countryMetadataResolver
+        @Named(COUNTRY_METADATA_RESOLVER) Optional<MetadataResolver> countryMetadataResolver
     ) {
         Map<Predicate<MatchingServiceRequestContext>, MatchingService> servicesMap = new LinkedHashMap<>();
         servicesMap.put((MatchingServiceRequestContext ctx) -> ctx.getAssertions().isEmpty(), healthCheckMatchingService);
@@ -216,8 +216,10 @@ class MatchingServiceAdapterModule extends AbstractModule {
         @Named("CountryCertificateValidator") Optional<CertificateValidator> countryCertificateValidator,
         X509CertificateFactory x509CertificateFactory,
         MatchingServiceAdapterConfiguration configuration,
-        AssertionDecrypter assertionDecrypter
-    ) {
+        AssertionDecrypter assertionDecrypter,
+        UserIdHashFactory userIdHashFactory,
+        MatchingServiceProxy matchingServiceClient,
+        MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper responseMapper) {
         return countryMetadataResolver.map(countryMetadataResolver1 ->
             new EidasMatchingService(
                 new EidasAttributeQueryValidator(
@@ -231,8 +233,9 @@ class MatchingServiceAdapterModule extends AbstractModule {
                     assertionDecrypter,
                     configuration.getCountry().getHubConnectorEntityId()
                 ),
-                new EidasMatchingRequestToLMSRequestTransform()
-            ));
+                new EidasMatchingRequestToLMSRequestTransform(userIdHashFactory),
+                matchingServiceClient,
+                responseMapper));
     }
 
     @Provides
@@ -491,7 +494,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
     @Provides
     @Singleton
     public MatchingServiceAttributeQueryHandler matchingServiceAttributeQueryHandler(
-        AdapterToMatchingServiceProxy proxy,
+        MatchingServiceProxy proxy,
         InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper inboundMapper,
         MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper outboundMapper) {
         return new MatchingServiceAttributeQueryHandler(proxy, inboundMapper, outboundMapper);

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/domain/EidasLoa.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/domain/EidasLoa.java
@@ -1,0 +1,28 @@
+package uk.gov.ida.matchingserviceadapter.domain;
+
+import static java.util.Arrays.stream;
+
+public enum EidasLoa {
+    LOW("http://eidas.europa.eu/LoA/low"),
+
+    SUBSTANTIAL("http://eidas.europa.eu/LoA/substantial"),
+
+    HIGH("http://eidas.europa.eu/LoA/high");
+
+    private final String valueUri;
+
+    EidasLoa(String valueUri) {
+        this.valueUri = valueUri;
+    }
+
+    public String getValueUri() {
+        return this.valueUri;
+    }
+
+    public static EidasLoa valueOfUri(String eidasLoaUri) {
+        return stream(EidasLoa.values())
+            .filter(eidasLoa -> eidasLoa.getValueUri().equals(eidasLoaUri))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException(String.format("Unable to find eIDAS LOA for value URI [%s]", eidasLoaUri)));
+    }
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/domain/EidasToVerifyLoaTransformer.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/domain/EidasToVerifyLoaTransformer.java
@@ -1,0 +1,24 @@
+package uk.gov.ida.matchingserviceadapter.domain;
+
+import uk.gov.ida.matchingserviceadapter.rest.matchingservice.LevelOfAssuranceDto;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.hub.domain.LevelOfAssurance;
+
+import java.util.function.Function;
+
+public class EidasToVerifyLoaTransformer implements Function<EidasLoa, LevelOfAssuranceDto> {
+
+    @Override
+    public LevelOfAssuranceDto apply(EidasLoa eidasLoa) {
+        switch( eidasLoa ) {
+            case LOW:
+                return LevelOfAssuranceDto.LEVEL_1;
+            case SUBSTANTIAL:
+                return LevelOfAssuranceDto.LEVEL_2;
+            case HIGH:
+                return LevelOfAssuranceDto.LEVEL_3;
+            default:
+                throw new IllegalArgumentException(String.format("Unable to convert Eidas level of assurance '%s' to Verify loa", eidasLoa));
+        }
+    }
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/AttributeQueryValidationException.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/AttributeQueryValidationException.java
@@ -1,0 +1,8 @@
+package uk.gov.ida.matchingserviceadapter.exceptions;
+
+public class AttributeQueryValidationException extends RuntimeException {
+
+    public AttributeQueryValidationException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/mappers/InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/mappers/InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper.java
@@ -13,6 +13,7 @@ import uk.gov.ida.saml.core.domain.AuthnContext;
 import uk.gov.ida.saml.core.domain.Cycle3Dataset;
 import uk.gov.ida.saml.core.domain.HubAssertion;
 import uk.gov.ida.saml.core.domain.IdentityProviderAssertion;
+import uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement;
 import uk.gov.ida.saml.core.domain.MatchingDataset;
 
 import static com.google.common.base.Optional.absent;
@@ -20,17 +21,13 @@ import static com.google.common.base.Optional.absent;
 public class InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper {
 
     private final UserIdHashFactory userIdHashFactory;
-    private final MatchingServiceAdapterConfiguration matchingServiceAdapterConfiguration;
     private final MatchingDatasetToMatchingDatasetDtoMapper matchingDatasetToMatchingDatasetDtoMapper;
 
     @Inject
     public InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper(
-            UserIdHashFactory userIdHashFactory,
-            MatchingServiceAdapterConfiguration matchingServiceAdapterConfiguration,
-            MatchingDatasetToMatchingDatasetDtoMapper matchingDatasetToMatchingDatasetDtoMapper) {
-
+        UserIdHashFactory userIdHashFactory, MatchingServiceAdapterConfiguration matchingServiceAdapterConfiguration,
+        MatchingDatasetToMatchingDatasetDtoMapper matchingDatasetToMatchingDatasetDtoMapper) {
         this.userIdHashFactory = userIdHashFactory;
-        this.matchingServiceAdapterConfiguration = matchingServiceAdapterConfiguration;
         this.matchingDatasetToMatchingDatasetDtoMapper = matchingDatasetToMatchingDatasetDtoMapper;
     }
 
@@ -39,7 +36,9 @@ public class InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper {
         IdentityProviderAssertion authnStatementAssertion = attributeQuery.getAuthnStatementAssertion();
         MatchingDataset matchingDataset = matchingDatasetAssertion.getMatchingDataset().get();
 
-        final String hashedPid = userIdHashFactory.createHashedId(matchingDatasetAssertion.getIssuerId(), matchingServiceAdapterConfiguration.getEntityId(), matchingDatasetAssertion.getPersistentId().getNameId(), authnStatementAssertion.getAuthnStatement());
+        final String hashedPid = userIdHashFactory.hashId(matchingDatasetAssertion.getIssuerId(),
+            matchingDatasetAssertion.getPersistentId().getNameId(),
+            authnStatementAssertion.getAuthnStatement().transform(IdentityProviderAuthnStatement::getAuthnContext));
 
         Optional<HubAssertion> cycle3AttributeAssertion = attributeQuery.getCycle3AttributeAssertion();
         Optional<Cycle3Dataset> cycle3Dataset = absent();

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/mappers/MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/mappers/MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper.java
@@ -2,20 +2,17 @@ package uk.gov.ida.matchingserviceadapter.mappers;
 
 import com.google.inject.Inject;
 import org.joda.time.DateTime;
-import org.opensaml.saml.saml2.core.Attribute;
 import uk.gov.ida.matchingserviceadapter.MatchingServiceAdapterConfiguration;
 import uk.gov.ida.matchingserviceadapter.configuration.AssertionLifetimeConfiguration;
 import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceAssertion;
 import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceAssertionFactory;
 import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceResponseDto;
-import uk.gov.ida.matchingserviceadapter.saml.transformers.inbound.InboundMatchingServiceRequest;
 import uk.gov.ida.matchingserviceadapter.saml.transformers.outbound.OutboundResponseFromMatchingService;
 import uk.gov.ida.saml.core.domain.AssertionRestrictions;
+import uk.gov.ida.saml.core.domain.AuthnContext;
 import uk.gov.ida.saml.core.domain.PersistentId;
 
 import java.util.ArrayList;
-import java.util.List;
-
 
 public class MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper {
     private final MatchingServiceAdapterConfiguration configuration;
@@ -23,44 +20,58 @@ public class MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapp
     private final AssertionLifetimeConfiguration assertionLifetimeConfiguration;
 
     @Inject
-    public MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper(MatchingServiceAdapterConfiguration configuration, MatchingServiceAssertionFactory outboundAssertionFactory, AssertionLifetimeConfiguration assertionLifetimeConfiguration) {
+    public MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper(
+        MatchingServiceAdapterConfiguration configuration,
+        MatchingServiceAssertionFactory outboundAssertionFactory,
+        AssertionLifetimeConfiguration assertionLifetimeConfiguration) {
+
         this.configuration = configuration;
         this.outboundAssertionFactory = outboundAssertionFactory;
         this.assertionLifetimeConfiguration = assertionLifetimeConfiguration;
     }
 
-    public OutboundResponseFromMatchingService map(MatchingServiceResponseDto response, String hashPid, InboundMatchingServiceRequest attributeQuery) {
+    public OutboundResponseFromMatchingService map(
+        MatchingServiceResponseDto response,
+        String hashPid,
+        String requestId,
+        String assertionConsumerServiceUrl,
+        AuthnContext authnContext,
+        String authnRequestIssuerId) {
+
         String result = response.getResult();
 
         switch (result) {
             case MatchingServiceResponseDto.MATCH:
-                return getMatchResponse(hashPid, attributeQuery, new ArrayList<>());
+                return getMatchResponse(hashPid, requestId, assertionConsumerServiceUrl, authnContext, authnRequestIssuerId);
             case MatchingServiceResponseDto.NO_MATCH:
-                return OutboundResponseFromMatchingService.createNoMatchFromMatchingService(attributeQuery.getId(), configuration.getEntityId());
+                return OutboundResponseFromMatchingService.createNoMatchFromMatchingService(requestId, configuration.getEntityId());
             default:
                 throw new UnsupportedOperationException("The matching service has returned an unsupported response message.");
         }
     }
 
     private OutboundResponseFromMatchingService getMatchResponse(
-            final String hashPid,
-            final InboundMatchingServiceRequest attributeQuery,
-            final List<Attribute> userAttributesForAccountCreation) {
+        final String hashPid,
+        final String requestId,
+        final String assertionConsumerServiceUrl,
+        final AuthnContext authnContext,
+        final String authnRequestIssuerId) {
+
         AssertionRestrictions assertionRestrictions = new AssertionRestrictions(
                 DateTime.now().plus(assertionLifetimeConfiguration.getAssertionLifetime().toMilliseconds()),
-                attributeQuery.getId(),
-                attributeQuery.getAssertionConsumerServiceUrl());
+                requestId,
+                assertionConsumerServiceUrl);
 
         MatchingServiceAssertion assertion = outboundAssertionFactory.createAssertionFromMatchingService(
                 new PersistentId(hashPid),
                 configuration.getEntityId(),
                 assertionRestrictions,
-                attributeQuery.getAuthnStatementAssertion().getAuthnStatement().get().getAuthnContext(),
-                attributeQuery.getAuthnRequestIssuerId(),
-                userAttributesForAccountCreation);
+                authnContext,
+                authnRequestIssuerId,
+                new ArrayList<>());
         return OutboundResponseFromMatchingService.createMatchFromMatchingService(
                 assertion,
-                attributeQuery.getId(),
+                requestId,
                 configuration.getEntityId()
         );
     }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/proxies/MatchingServiceProxy.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/proxies/MatchingServiceProxy.java
@@ -6,7 +6,7 @@ import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceResponseDto;
 import uk.gov.ida.matchingserviceadapter.rest.UnknownUserCreationRequestDto;
 import uk.gov.ida.matchingserviceadapter.rest.UnknownUserCreationResponseDto;
 
-public interface AdapterToMatchingServiceProxy {
+public interface MatchingServiceProxy {
     MatchingServiceResponseDto makeMatchingServiceRequest(MatchingServiceRequestDto attributeQuery);
     UnknownUserCreationResponseDto makeUnknownUserCreationRequest(UnknownUserCreationRequestDto attributeQuery);
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/proxies/MatchingServiceProxyImpl.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/proxies/MatchingServiceProxyImpl.java
@@ -3,8 +3,6 @@ package uk.gov.ida.matchingserviceadapter.proxies;
 import com.codahale.metrics.annotation.Timed;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.ida.jerseyclient.JsonClient;
 import uk.gov.ida.matchingserviceadapter.MatchingServiceAdapterConfiguration;
 import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceRequestDto;
@@ -14,15 +12,13 @@ import uk.gov.ida.matchingserviceadapter.rest.UnknownUserCreationResponseDto;
 
 import java.net.URI;
 
-public class AdapterToMatchingServiceHttpProxy implements AdapterToMatchingServiceProxy {
-
-    private static final Logger LOG = LoggerFactory.getLogger(AdapterToMatchingServiceHttpProxy.class);
+public class MatchingServiceProxyImpl implements MatchingServiceProxy {
 
     private final JsonClient client;
     private final MatchingServiceAdapterConfiguration configuration;
 
     @Inject
-    public AdapterToMatchingServiceHttpProxy(@Named("MatchingServiceClient") JsonClient client, MatchingServiceAdapterConfiguration configuration) {
+    public MatchingServiceProxyImpl(@Named("MatchingServiceClient") JsonClient client, MatchingServiceAdapterConfiguration configuration) {
         this.client = client;
         this.configuration = configuration;
     }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/rest/MatchingServiceRequestDto.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/rest/MatchingServiceRequestDto.java
@@ -5,6 +5,7 @@ import com.google.common.base.Optional;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import uk.gov.ida.matchingserviceadapter.rest.matchingservice.Cycle3DatasetDto;
+import uk.gov.ida.matchingserviceadapter.rest.matchingservice.EidasMatchingDataset;
 import uk.gov.ida.matchingserviceadapter.rest.matchingservice.LevelOfAssuranceDto;
 import uk.gov.ida.matchingserviceadapter.rest.matchingservice.MatchingDatasetDto;
 
@@ -15,6 +16,7 @@ public class MatchingServiceRequestDto {
 
     private MatchingDatasetDto matchingDataset;
     private Optional<Cycle3DatasetDto> cycle3Dataset = Optional.absent();
+    private EidasMatchingDataset eidasDataset;
     private String hashedPid;
     private String matchId;
     private LevelOfAssuranceDto levelOfAssurance;
@@ -30,6 +32,20 @@ public class MatchingServiceRequestDto {
             LevelOfAssuranceDto levelOfAssurance) {
 
         this.matchingDataset = matchingDataset;
+        this.cycle3Dataset = cycle3Dataset;
+        this.hashedPid = hashedPid;
+        this.matchId = matchId;
+        this.levelOfAssurance = levelOfAssurance;
+    }
+
+    public MatchingServiceRequestDto(
+        EidasMatchingDataset eidasDataset,
+        Optional<Cycle3DatasetDto> cycle3Dataset,
+        String hashedPid,
+        String matchId,
+        LevelOfAssuranceDto levelOfAssurance) {
+
+        this.eidasDataset = eidasDataset;
         this.cycle3Dataset = cycle3Dataset;
         this.hashedPid = hashedPid;
         this.matchId = matchId;
@@ -55,6 +71,10 @@ public class MatchingServiceRequestDto {
 
     public LevelOfAssuranceDto getLevelOfAssurance() {
         return levelOfAssurance;
+    }
+
+    public EidasMatchingDataset getEidasDataset() {
+        return eidasDataset;
     }
 
     @Override

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/rest/matchingservice/EidasMatchingDataset.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/rest/matchingservice/EidasMatchingDataset.java
@@ -1,0 +1,112 @@
+package uk.gov.ida.matchingserviceadapter.rest.matchingservice;
+
+import com.google.common.base.Optional;
+import org.joda.time.LocalDate;
+
+public class EidasMatchingDataset {
+    private final Address address;
+    private final LocalDate dateOfBirth;
+    private final String firstName;
+    private final String gender;
+    private final String familyName;
+    private final String birthName;
+    private final String placeOfBirth;
+
+    public EidasMatchingDataset(Address address, LocalDate dateOfBirth, String firstName, String familyName, String birthName, String gender, String placeOfBirth) {
+        this.address = address;
+        this.dateOfBirth = dateOfBirth;
+        this.firstName = firstName;
+        this.gender = gender;
+        this.familyName = familyName;
+        this.birthName = birthName;
+        this.placeOfBirth = placeOfBirth;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public LocalDate getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public String getFamilyName() {
+        return familyName;
+    }
+
+    public String getBirthName() {
+        return birthName;
+    }
+
+    public String getPlaceOfBirth() {
+        return placeOfBirth;
+    }
+
+    public static class Address {
+        private final String poBox;
+        private final String locatorDesignator;
+        private final String locatorName;
+        private final String cvAddressArea;
+        private final String thoroughFare;
+        private final String postName;
+        private final String adminunitFirstLine;
+        private final String adminunitSecondLine;
+        private final String postCode;
+
+        public Address(String poBox, String locatorDesignator, String locatorName, String cvAddressArea, String throroughFare, String postName, String adminunitFirstLine, String adminunitSecondLine, String postCode) {
+            this.poBox = poBox;
+            this.locatorDesignator = locatorDesignator;
+            this.locatorName = locatorName;
+            this.cvAddressArea = cvAddressArea;
+            this.thoroughFare = throroughFare;
+            this.postName = postName;
+            this.adminunitFirstLine = adminunitFirstLine;
+            this.adminunitSecondLine = adminunitSecondLine;
+            this.postCode = postCode;
+        }
+
+        public String getPoBox() {
+            return poBox;
+        }
+
+        public String getLocatorDesignator() {
+            return locatorDesignator;
+        }
+
+        public String getLocatorName() {
+            return locatorName;
+        }
+
+        public String getCvAddressArea() {
+            return cvAddressArea;
+        }
+
+        public String getThoroughFare() {
+            return thoroughFare;
+        }
+
+        public String getPostName() {
+            return postName;
+        }
+
+        public String getAdminunitFirstLine() {
+            return adminunitFirstLine;
+        }
+
+        public String getAdminunitSecondLine() {
+            return adminunitSecondLine;
+        }
+
+        public String getPostCode() {
+            return postCode;
+        }
+    }
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/rest/matchingservice/EidasMatchingDataset.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/rest/matchingservice/EidasMatchingDataset.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.matchingserviceadapter.rest.matchingservice;
 
-import com.google.common.base.Optional;
 import org.joda.time.LocalDate;
 
 public class EidasMatchingDataset {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/rest/matchingservice/MdsValueOnlyDto.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/rest/matchingservice/MdsValueOnlyDto.java
@@ -1,0 +1,33 @@
+package uk.gov.ida.matchingserviceadapter.rest.matchingservice;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.joda.time.DateTime;
+
+@JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
+public class MdsValueOnlyDto<T> {
+
+    private T value;
+
+    @SuppressWarnings("unused") // needed for JAXB
+    public MdsValueOnlyDto() {}
+
+    public MdsValueOnlyDto(T value) {
+        this.value = value;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/saml/UserIdHashFactory.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/saml/UserIdHashFactory.java
@@ -4,47 +4,51 @@ import com.google.common.base.Optional;
 import org.apache.commons.codec.binary.Hex;
 import org.opensaml.security.crypto.JCAConstants;
 import uk.gov.ida.saml.core.domain.AuthnContext;
-import uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement;
 
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
 
-import static com.google.common.base.Throwables.propagate;
-
 public class UserIdHashFactory {
-    public String createHashedId(String partnerEntityId, String entityId, String persistentId, Optional<IdentityProviderAuthnStatement> authnStatement) {
+
+    private final String msaEntityId;
+
+    public UserIdHashFactory(String msaEntityId) {
+        this.msaEntityId = msaEntityId;
+    }
+
+    public String hashId(String issuerEntityId, String persistentId, Optional<AuthnContext> authnContext) {
         MessageDigest md;
         try {
             md = MessageDigest.getInstance(JCAConstants.DIGEST_SHA256);
         } catch (NoSuchAlgorithmException e) {
-            throw propagate(e);
+            throw new RuntimeException(e);
         }
 
-        final String persistentIdHash = getPersistentIdHashForDigest(partnerEntityId, entityId, persistentId, authnStatement);
+        final String toHash = idToHash(issuerEntityId, persistentId, authnContext);
 
         try {
-            md.update(persistentIdHash.getBytes("UTF-8"));
+            md.update(toHash.getBytes("UTF-8"));
         } catch (UnsupportedEncodingException e) {
-            throw propagate(e);
+            throw new RuntimeException(e);
         }
 
         byte[] digest = md.digest();
         return Hex.encodeHexString(digest);
     }
 
-    private String getPersistentIdHashForDigest(String partnerEntityId, String entityId, String persistentId, Optional<IdentityProviderAuthnStatement> authnStatement) {
+    private String idToHash(String issuerEntityId, String persistentId, Optional<AuthnContext> context) {
         String persistentIdHash;
 
-        final AuthnContext authnContext = authnStatement.get().getAuthnContext();
+        final AuthnContext authnContext = context.toJavaUtil().orElseThrow(() -> new IllegalStateException(String.format("Authn context absent for persistent id %s", persistentId)));
         if(authnContext.equals(AuthnContext.LEVEL_2)) {
             // default behaviour - for LEVEL_2
-            persistentIdHash = MessageFormat.format("{0}{1}{2}", partnerEntityId, entityId, persistentId);
+            persistentIdHash = MessageFormat.format("{0}{1}{2}", issuerEntityId, msaEntityId, persistentId);
         } else {
             // if we have an authnContext that is not LEVEL_2 then regenerate the hash
             // this does not break existing behaviour for LEVEL_2 RPs
-            persistentIdHash = MessageFormat.format("{0}{1}{2}{3}", partnerEntityId, entityId, persistentId, authnContext.name());
+            persistentIdHash = MessageFormat.format("{0}{1}{2}{3}", issuerEntityId, msaEntityId, persistentId, authnContext.name());
         }
         return persistentIdHash;
     }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/EidasAttributeQueryToInboundMatchingServiceRequestTransformer.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/EidasAttributeQueryToInboundMatchingServiceRequestTransformer.java
@@ -2,6 +2,7 @@ package uk.gov.ida.matchingserviceadapter.saml.transformers.inbound.transformers
 
 import com.google.inject.Inject;
 import org.opensaml.saml.saml2.core.AttributeQuery;
+import uk.gov.ida.matchingserviceadapter.saml.UserIdHashFactory;
 import uk.gov.ida.matchingserviceadapter.saml.transformers.inbound.InboundMatchingServiceRequest;
 import uk.gov.ida.validation.messages.Messages;
 import uk.gov.ida.validation.validators.Validator;

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/InboundMatchingServiceRequestUnmarshaller.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/InboundMatchingServiceRequestUnmarshaller.java
@@ -50,9 +50,8 @@ public class InboundMatchingServiceRequestUnmarshaller {
             }
         }
 
-
-        String spNameQualifier = subject.getNameID().getSPNameQualifier(); // this is the authn request issuer id
-        String nameQualifier = subject.getNameID().getNameQualifier(); // this is the assertion consumer url
+        String authnRequestIssuerId = subject.getNameID().getSPNameQualifier();
+        String assertionConsumerUrl = subject.getNameID().getNameQualifier();
 
         return new InboundMatchingServiceRequest(
                 id,
@@ -61,8 +60,8 @@ public class InboundMatchingServiceRequestUnmarshaller {
                 authnStatementAssertion,
                 cycle3AttributeAssertion,
                 originalQuery.getIssueInstant(),
-                spNameQualifier,
-                nameQualifier,
+                authnRequestIssuerId,
+                assertionConsumerUrl,
                 originalQuery.getAttributes()
         );
     }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingRequestToLMSRequestTransform.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingRequestToLMSRequestTransform.java
@@ -3,57 +3,58 @@ package uk.gov.ida.matchingserviceadapter.services;
 import org.joda.time.LocalDate;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
-import org.opensaml.saml.saml2.core.AttributeValue;
-import org.opensaml.saml.saml2.metadata.GivenName;
-import org.opensaml.saml.saml2.metadata.SurName;
 import uk.gov.ida.matchingserviceadapter.domain.EidasLoa;
 import uk.gov.ida.matchingserviceadapter.domain.EidasToVerifyLoaTransformer;
 import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceRequestContext;
 import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceRequestDto;
 import uk.gov.ida.matchingserviceadapter.rest.matchingservice.EidasMatchingDataset;
 import uk.gov.ida.matchingserviceadapter.rest.matchingservice.LevelOfAssuranceDto;
-import uk.gov.ida.matchingserviceadapter.rest.matchingservice.MdsValueOnlyDto;
-import uk.gov.ida.matchingserviceadapter.rest.matchingservice.SimpleMdsValueDto;
+import uk.gov.ida.matchingserviceadapter.saml.UserIdHashFactory;
 import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.IdaConstants.Eidas_Attributes;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.extensions.eidas.BirthName;
 import uk.gov.ida.saml.core.extensions.eidas.CurrentFamilyName;
 import uk.gov.ida.saml.core.extensions.eidas.CurrentGivenName;
 import uk.gov.ida.saml.core.extensions.eidas.DateOfBirth;
 import uk.gov.ida.saml.core.extensions.eidas.Gender;
 import uk.gov.ida.saml.core.extensions.eidas.PersonIdentifier;
+import uk.gov.ida.saml.core.extensions.eidas.PlaceOfBirth;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static com.google.common.base.Optional.of;
 
 public class EidasMatchingRequestToLMSRequestTransform implements Function<MatchingServiceRequestContext, MatchingServiceRequestDto> {
-    public static final String GIVEN_NAME="http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName";
-    public static final String FAMILY_NAME="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName";
-    public static final String BIRTH_NAME="http://eidas.europa.eu/attributes/naturalperson/BirthName";
-    public static final String PLACE_OF_BIRTH="http://eidas.europa.eu/attributes/naturalperson/PlaceOfBirth";
-    public static final String DOB="http://eidas.europa.eu/attributes/naturalperson/DateOfBirth";
-    public static final String PID="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier";
-    public static final String CURRENT_ADDRESS="http://eidas.europa.eu/attributes/naturalperson/CurrentAddress";
-    public static final String GENDER="http://eidas.europa.eu/attributes/naturalperson/Gender";
 
     private EidasToVerifyLoaTransformer eidasToVerifyLoaTransformer = new EidasToVerifyLoaTransformer();
+    private UserIdHashFactory userIdHashFactory;
+
+    public EidasMatchingRequestToLMSRequestTransform(UserIdHashFactory userIdHashFactory) {
+        this.userIdHashFactory = userIdHashFactory;
+    }
 
     @Override
     public MatchingServiceRequestDto apply(MatchingServiceRequestContext matchingServiceRequestContext) {
         Assertion assertion = matchingServiceRequestContext.getAssertions().get(0);
+        List<Attribute> attributes = assertion.getAttributeStatements().get(0).getAttributes();
 
-        return new MatchingServiceRequestDto((EidasMatchingDataset) extractEidasMatchingDataset(assertion),
-                                             com.google.common.base.Optional.absent(),
-                                             extractPid(assertion),
-                                             null,
-                                             extractVerifyLoa(assertion));
+        return new MatchingServiceRequestDto(extractEidasMatchingDataset(attributes),
+            com.google.common.base.Optional.absent(),
+            extractAndHashPid(assertion),
+            matchingServiceRequestContext.getAttributeQuery().getID(),
+            extractVerifyLoa(assertion));
     }
 
     private LevelOfAssuranceDto extractVerifyLoa(Assertion assertion) {
         return eidasToVerifyLoaTransformer.apply(EidasLoa.valueOfUri(assertion.getAuthnStatements().get(0).getAuthnContext().getAuthnContextClassRef().getAuthnContextClassRef()));
     }
 
-    private String extractPid(Assertion assertion) {
-        return assertion.getAttributeStatements()
+    private String extractAndHashPid(Assertion assertion) {
+        String euPid = assertion.getAttributeStatements()
             .get(0)
             .getAttributes()
             .stream()
@@ -61,67 +62,38 @@ public class EidasMatchingRequestToLMSRequestTransform implements Function<Match
             .findFirst()
             .map(Attribute::getAttributeValues)
             .map(vs -> vs.get(0))
-            .map(v -> ((PersonIdentifier)v).getPersonIdentifier())
+            .map(v -> ((PersonIdentifier) v).getPersonIdentifier())
             .get();
+        return userIdHashFactory.hashId(assertion.getIssuer().getValue(),
+            euPid,
+            of(AuthnContext.valueOf(extractVerifyLoa(assertion).name())));
     }
 
-    private EidasMatchingDataset extractEidasMatchingDataset(Assertion assertion) {
-        List<Attribute> attributes = assertion.getAttributeStatements()
-            .get(0)
-            .getAttributes();
-        Optional<LocalDate> dob = attributes.stream()
-            .filter(a -> a.getName().equals(DOB))
-            .findFirst()
-            .map(Attribute::getAttributeValues)
-            .map(vs -> vs.get(0))
-            .map(v -> ((DateOfBirth) v))
-            .map(DateOfBirth::getDateOfBirth);
-
-        Optional<String> givenName = attributes.stream()
-            .filter(a -> a.getName().equals(GIVEN_NAME))
-            .findFirst()
-            .map(Attribute::getAttributeValues)
-            .map(vs -> vs.get(0))
-            .map(v -> ((CurrentGivenName) v))
-            .map(CurrentGivenName::getFirstName);
-
-        Optional<String> familyName = attributes.stream()
-            .filter(a -> a.getName().equals(FAMILY_NAME))
-            .findFirst()
-            .map(Attribute::getAttributeValues)
-            .map(vs -> vs.get(0))
-            .map(v -> ((CurrentFamilyName) v))
-            .map(CurrentFamilyName::getFamilyName);
-
-        Optional<String> birthName = attributes.stream()
-            .filter(a -> a.getName().equals(BIRTH_NAME))
-            .findFirst()
-            .map(Attribute::getAttributeValues)
-            .map(vs -> vs.get(0))
-            .map(av -> av.getDOM().getTextContent());
-
-        Optional<String> placeOfBirth = attributes.stream()
-            .filter(a -> a.getName().equals(PLACE_OF_BIRTH))
-            .findFirst()
-            .map(Attribute::getAttributeValues)
-            .map(vs -> vs.get(0))
-            .map(av -> av.getDOM().getTextContent());
-
-        Optional<String> gender = attributes.stream()
-            .filter(a -> a.getName().equals(GENDER))
-            .findFirst()
-            .map(Attribute::getAttributeValues)
-            .map(vs -> vs.get(0))
-            .map(v -> ((Gender) v))
-            .map(Gender::getValue);
+    private EidasMatchingDataset extractEidasMatchingDataset(List<Attribute> attributes) {
+        Optional<LocalDate> dob = getAttributeValue(attributes, a -> a.getName().equals(Eidas_Attributes.DateOfBirth.NAME), DateOfBirth.class, DateOfBirth::getDateOfBirth);
+        Optional<String> givenName = getAttributeValue(attributes, a -> a.getName().equals(Eidas_Attributes.FirstName.NAME), CurrentGivenName.class, CurrentGivenName::getFirstName);
+        Optional<String> familyName = getAttributeValue(attributes, a -> a.getName().equals(Eidas_Attributes.FamilyName.NAME), CurrentFamilyName.class, CurrentFamilyName::getFamilyName);
+        Optional<String> birthName = getAttributeValue(attributes, a -> a.getName().equals(Eidas_Attributes.BirthName.NAME), BirthName.class, BirthName::getBirthName);
+        Optional<String> placeOfBirth = getAttributeValue(attributes, a -> a.getName().equals(Eidas_Attributes.PlaceOfBirth.NAME), PlaceOfBirth.class, PlaceOfBirth::getPlaceOfBirth);
+        Optional<String> gender = getAttributeValue(attributes, a -> a.getName().equals(Eidas_Attributes.Gender.NAME), Gender.class, Gender::getValue);
 
         return new EidasMatchingDataset(null,
-                                        dob.orElse(null),
-                                        givenName.orElse(null),
-                                        familyName.orElse(null),
-                                        birthName.orElse(null),
-                                        gender.orElse(null),
-                                        placeOfBirth.orElse(null)
+            dob.orElse(null),
+            givenName.orElse(null),
+            familyName.orElse(null),
+            birthName.orElse(null),
+            gender.orElse(null),
+            placeOfBirth.orElse(null)
         );
+    }
+
+    private <T, V> Optional<V> getAttributeValue(List<Attribute> attributes, Predicate<Attribute> filter, Class<T> clazz, Function<T, V> transformer) {
+        return attributes.stream()
+            .filter(filter)
+            .findFirst()
+            .map(Attribute::getAttributeValues)
+            .map(vs -> vs.get(0))
+            .map(clazz::cast)
+            .map(transformer);
     }
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingRequestToLMSRequestTransform.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingRequestToLMSRequestTransform.java
@@ -1,0 +1,127 @@
+package uk.gov.ida.matchingserviceadapter.services;
+
+import org.joda.time.LocalDate;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeValue;
+import org.opensaml.saml.saml2.metadata.GivenName;
+import org.opensaml.saml.saml2.metadata.SurName;
+import uk.gov.ida.matchingserviceadapter.domain.EidasLoa;
+import uk.gov.ida.matchingserviceadapter.domain.EidasToVerifyLoaTransformer;
+import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceRequestContext;
+import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceRequestDto;
+import uk.gov.ida.matchingserviceadapter.rest.matchingservice.EidasMatchingDataset;
+import uk.gov.ida.matchingserviceadapter.rest.matchingservice.LevelOfAssuranceDto;
+import uk.gov.ida.matchingserviceadapter.rest.matchingservice.MdsValueOnlyDto;
+import uk.gov.ida.matchingserviceadapter.rest.matchingservice.SimpleMdsValueDto;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.extensions.eidas.CurrentFamilyName;
+import uk.gov.ida.saml.core.extensions.eidas.CurrentGivenName;
+import uk.gov.ida.saml.core.extensions.eidas.DateOfBirth;
+import uk.gov.ida.saml.core.extensions.eidas.Gender;
+import uk.gov.ida.saml.core.extensions.eidas.PersonIdentifier;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class EidasMatchingRequestToLMSRequestTransform implements Function<MatchingServiceRequestContext, MatchingServiceRequestDto> {
+    public static final String GIVEN_NAME="http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName";
+    public static final String FAMILY_NAME="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName";
+    public static final String BIRTH_NAME="http://eidas.europa.eu/attributes/naturalperson/BirthName";
+    public static final String PLACE_OF_BIRTH="http://eidas.europa.eu/attributes/naturalperson/PlaceOfBirth";
+    public static final String DOB="http://eidas.europa.eu/attributes/naturalperson/DateOfBirth";
+    public static final String PID="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier";
+    public static final String CURRENT_ADDRESS="http://eidas.europa.eu/attributes/naturalperson/CurrentAddress";
+    public static final String GENDER="http://eidas.europa.eu/attributes/naturalperson/Gender";
+
+    private EidasToVerifyLoaTransformer eidasToVerifyLoaTransformer = new EidasToVerifyLoaTransformer();
+
+    @Override
+    public MatchingServiceRequestDto apply(MatchingServiceRequestContext matchingServiceRequestContext) {
+        Assertion assertion = matchingServiceRequestContext.getAssertions().get(0);
+
+        return new MatchingServiceRequestDto((EidasMatchingDataset) extractEidasMatchingDataset(assertion),
+                                             com.google.common.base.Optional.absent(),
+                                             extractPid(assertion),
+                                             null,
+                                             extractVerifyLoa(assertion));
+    }
+
+    private LevelOfAssuranceDto extractVerifyLoa(Assertion assertion) {
+        return eidasToVerifyLoaTransformer.apply(EidasLoa.valueOfUri(assertion.getAuthnStatements().get(0).getAuthnContext().getAuthnContextClassRef().getAuthnContextClassRef()));
+    }
+
+    private String extractPid(Assertion assertion) {
+        return assertion.getAttributeStatements()
+            .get(0)
+            .getAttributes()
+            .stream()
+            .filter(a -> a.getName().equals(IdaConstants.Eidas_Attributes.PersonIdentifier.NAME))
+            .findFirst()
+            .map(Attribute::getAttributeValues)
+            .map(vs -> vs.get(0))
+            .map(v -> ((PersonIdentifier)v).getPersonIdentifier())
+            .get();
+    }
+
+    private EidasMatchingDataset extractEidasMatchingDataset(Assertion assertion) {
+        List<Attribute> attributes = assertion.getAttributeStatements()
+            .get(0)
+            .getAttributes();
+        Optional<LocalDate> dob = attributes.stream()
+            .filter(a -> a.getName().equals(DOB))
+            .findFirst()
+            .map(Attribute::getAttributeValues)
+            .map(vs -> vs.get(0))
+            .map(v -> ((DateOfBirth) v))
+            .map(DateOfBirth::getDateOfBirth);
+
+        Optional<String> givenName = attributes.stream()
+            .filter(a -> a.getName().equals(GIVEN_NAME))
+            .findFirst()
+            .map(Attribute::getAttributeValues)
+            .map(vs -> vs.get(0))
+            .map(v -> ((CurrentGivenName) v))
+            .map(CurrentGivenName::getFirstName);
+
+        Optional<String> familyName = attributes.stream()
+            .filter(a -> a.getName().equals(FAMILY_NAME))
+            .findFirst()
+            .map(Attribute::getAttributeValues)
+            .map(vs -> vs.get(0))
+            .map(v -> ((CurrentFamilyName) v))
+            .map(CurrentFamilyName::getFamilyName);
+
+        Optional<String> birthName = attributes.stream()
+            .filter(a -> a.getName().equals(BIRTH_NAME))
+            .findFirst()
+            .map(Attribute::getAttributeValues)
+            .map(vs -> vs.get(0))
+            .map(av -> av.getDOM().getTextContent());
+
+        Optional<String> placeOfBirth = attributes.stream()
+            .filter(a -> a.getName().equals(PLACE_OF_BIRTH))
+            .findFirst()
+            .map(Attribute::getAttributeValues)
+            .map(vs -> vs.get(0))
+            .map(av -> av.getDOM().getTextContent());
+
+        Optional<String> gender = attributes.stream()
+            .filter(a -> a.getName().equals(GENDER))
+            .findFirst()
+            .map(Attribute::getAttributeValues)
+            .map(vs -> vs.get(0))
+            .map(v -> ((Gender) v))
+            .map(Gender::getValue);
+
+        return new EidasMatchingDataset(null,
+                                        dob.orElse(null),
+                                        givenName.orElse(null),
+                                        familyName.orElse(null),
+                                        birthName.orElse(null),
+                                        gender.orElse(null),
+                                        placeOfBirth.orElse(null)
+        );
+    }
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingService.java
@@ -4,8 +4,12 @@ package uk.gov.ida.matchingserviceadapter.services;
 import org.opensaml.saml.saml2.core.AttributeQuery;
 import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceRequestContext;
 import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceResponse;
+import uk.gov.ida.matchingserviceadapter.exceptions.AttributeQueryValidationException;
+import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceRequestDto;
 import uk.gov.ida.validation.messages.Messages;
 import uk.gov.ida.validation.validators.Validator;
+
+import java.util.function.Function;
 
 import static uk.gov.ida.validation.messages.MessagesImpl.messages;
 
@@ -14,21 +18,32 @@ public class EidasMatchingService implements MatchingService {
         " Next stage of eIDAS MSA development is to validate the AQR";
 
     private Validator<AttributeQuery> validator;
+    private Function<MatchingServiceRequestContext, MatchingServiceRequestDto> transformer;
 
-    public EidasMatchingService(Validator<AttributeQuery> validator) {
+    public EidasMatchingService(Validator<AttributeQuery> validator,
+                                Function<MatchingServiceRequestContext, MatchingServiceRequestDto> transformer) {
         this.validator = validator;
+        this.transformer = transformer;
     }
 
     public Validator<AttributeQuery> getValidator() {
         return validator;
     }
 
+    public Function<MatchingServiceRequestContext, MatchingServiceRequestDto> getTransformer() {
+        return transformer;
+    }
+
     @Override
     public MatchingServiceResponse handle(MatchingServiceRequestContext request) {
         Messages validationMessages = validator.validate(request.getAttributeQuery(), messages());
         if (validationMessages.hasErrors()) {
-            throw new RuntimeException("Eidas Attribute Query was invalid: " + validationMessages);
+            throw new AttributeQueryValidationException("Eidas Attribute Query was invalid: " + validationMessages);
         }
+
+        MatchingServiceRequestDto matchingServiceRequestDto = transformer.apply(request);
+
+        // EID-297: Use the MatchingServiceRequestDto created above tp return a MatchingServiceResponse
 
         // TODO - EID-202 handle attributes and fill out the nulls below
         throw new RuntimeException(TODO_MESSAGE);

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingService.java
@@ -4,34 +4,38 @@ package uk.gov.ida.matchingserviceadapter.services;
 import org.opensaml.saml.saml2.core.AttributeQuery;
 import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceRequestContext;
 import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceResponse;
+import uk.gov.ida.matchingserviceadapter.domain.VerifyMatchingServiceResponse;
 import uk.gov.ida.matchingserviceadapter.exceptions.AttributeQueryValidationException;
+import uk.gov.ida.matchingserviceadapter.mappers.MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper;
+import uk.gov.ida.matchingserviceadapter.proxies.MatchingServiceProxy;
 import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceRequestDto;
 import uk.gov.ida.validation.messages.Messages;
 import uk.gov.ida.validation.validators.Validator;
+import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceResponseDto;
+import uk.gov.ida.saml.core.transformers.AuthnContextFactory;
 
+import javax.inject.Inject;
 import java.util.function.Function;
 
 import static uk.gov.ida.validation.messages.MessagesImpl.messages;
 
 public class EidasMatchingService implements MatchingService {
-    public static final String TODO_MESSAGE = "TODO: Eidas Attribute Query and its identity assertion signatures are valid." +
-        " Next stage of eIDAS MSA development is to validate the AQR";
 
-    private Validator<AttributeQuery> validator;
-    private Function<MatchingServiceRequestContext, MatchingServiceRequestDto> transformer;
+    private final Validator<AttributeQuery> validator;
+    private final Function<MatchingServiceRequestContext, MatchingServiceRequestDto> transformer;
+    private final MatchingServiceProxy matchingServiceClient;
+    private final MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper responseMapper;
+    private final AuthnContextFactory authnContextFactory = new AuthnContextFactory();
 
+    @Inject
     public EidasMatchingService(Validator<AttributeQuery> validator,
-                                Function<MatchingServiceRequestContext, MatchingServiceRequestDto> transformer) {
+                                Function<MatchingServiceRequestContext, MatchingServiceRequestDto> transformer,
+                                MatchingServiceProxy matchingServiceClient,
+                                MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper responseMapper) {
         this.validator = validator;
         this.transformer = transformer;
-    }
-
-    public Validator<AttributeQuery> getValidator() {
-        return validator;
-    }
-
-    public Function<MatchingServiceRequestContext, MatchingServiceRequestDto> getTransformer() {
-        return transformer;
+        this.matchingServiceClient = matchingServiceClient;
+        this.responseMapper = responseMapper;
     }
 
     @Override
@@ -42,10 +46,17 @@ public class EidasMatchingService implements MatchingService {
         }
 
         MatchingServiceRequestDto matchingServiceRequestDto = transformer.apply(request);
+        MatchingServiceResponseDto responseFromMatchingService = matchingServiceClient.makeMatchingServiceRequest(matchingServiceRequestDto);
 
-        // EID-297: Use the MatchingServiceRequestDto created above tp return a MatchingServiceResponse
-
-        // TODO - EID-202 handle attributes and fill out the nulls below
-        throw new RuntimeException(TODO_MESSAGE);
+        return new VerifyMatchingServiceResponse(
+            responseMapper.map(
+                responseFromMatchingService,
+                matchingServiceRequestDto.getHashedPid(),
+                request.getAttributeQuery().getID(),
+                request.getAttributeQuery().getSubject().getNameID().getNameQualifier(),
+                authnContextFactory.mapFromEidasToLoA(request.getAssertions().get(0).getAuthnStatements().get(0).getAuthnContext().getAuthnContextClassRef().getAuthnContextClassRef()),
+                request.getAttributeQuery().getSubject().getNameID().getSPNameQualifier()
+            )
+        );
     }
 }

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/controllogic/MatchingServiceAttributeQueryHandlerTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/controllogic/MatchingServiceAttributeQueryHandlerTest.java
@@ -6,7 +6,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ida.matchingserviceadapter.mappers.InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper;
 import uk.gov.ida.matchingserviceadapter.mappers.MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper;
-import uk.gov.ida.matchingserviceadapter.proxies.AdapterToMatchingServiceProxy;
+import uk.gov.ida.matchingserviceadapter.proxies.MatchingServiceProxy;
 import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceRequestDto;
 import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceResponseDto;
 import uk.gov.ida.matchingserviceadapter.saml.transformers.inbound.InboundMatchingServiceRequest;
@@ -23,7 +23,7 @@ import static uk.gov.ida.matchingserviceadapter.builders.OutboundResponseFromMat
 public class MatchingServiceAttributeQueryHandlerTest {
 
     @Mock
-    AdapterToMatchingServiceProxy adapterToMatchingServiceProxy;
+    MatchingServiceProxy matchingServiceProxy;
 
     @Mock
     InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper queryDtoMapper;
@@ -40,10 +40,10 @@ public class MatchingServiceAttributeQueryHandlerTest {
         MatchingServiceResponseDto responseDto = aMatchingServiceResponseDto().build();
         OutboundResponseFromMatchingService idaResponse = aResponse().build();
 
-        MatchingServiceAttributeQueryHandler handler = new MatchingServiceAttributeQueryHandler(adapterToMatchingServiceProxy, queryDtoMapper, dtoResponseMapper);
+        MatchingServiceAttributeQueryHandler handler = new MatchingServiceAttributeQueryHandler(matchingServiceProxy, queryDtoMapper, dtoResponseMapper);
         when(queryDtoMapper.map(attributeQuery)).thenReturn(matchingServiceAttributeQuery);
-        when(adapterToMatchingServiceProxy.makeMatchingServiceRequest(matchingServiceAttributeQuery)).thenReturn(responseDto);
-        when(dtoResponseMapper.map(responseDto, hashedPid, attributeQuery)).thenReturn(idaResponse);
+        when(matchingServiceProxy.makeMatchingServiceRequest(matchingServiceAttributeQuery)).thenReturn(responseDto);
+        when(dtoResponseMapper.map(responseDto, hashedPid, attributeQuery.getId(), attributeQuery.getAssertionConsumerServiceUrl(), attributeQuery.getAuthnStatementAssertion().getAuthnStatement().get().getAuthnContext(), attributeQuery.getAuthnRequestIssuerId())).thenReturn(idaResponse);
         OutboundResponseFromMatchingService result = handler.handle(attributeQuery);
 
         assertThat(result).isEqualTo(idaResponse);

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserAttributeQueryHandlerTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserAttributeQueryHandlerTest.java
@@ -10,7 +10,7 @@ import uk.gov.ida.matchingserviceadapter.MatchingServiceAdapterConfiguration;
 import uk.gov.ida.matchingserviceadapter.configuration.AssertionLifetimeConfiguration;
 import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceAssertionFactory;
 import uk.gov.ida.matchingserviceadapter.domain.UserAccountCreationAttributeExtractor;
-import uk.gov.ida.matchingserviceadapter.proxies.AdapterToMatchingServiceProxy;
+import uk.gov.ida.matchingserviceadapter.proxies.MatchingServiceProxy;
 import uk.gov.ida.matchingserviceadapter.rest.UnknownUserCreationRequestDto;
 import uk.gov.ida.matchingserviceadapter.rest.UnknownUserCreationResponseDto;
 import uk.gov.ida.matchingserviceadapter.rest.matchingservice.LevelOfAssuranceDto;
@@ -18,15 +18,11 @@ import uk.gov.ida.matchingserviceadapter.saml.UserIdHashFactory;
 import uk.gov.ida.matchingserviceadapter.saml.transformers.inbound.InboundMatchingServiceRequest;
 import uk.gov.ida.matchingserviceadapter.saml.transformers.outbound.OutboundResponseFromUnknownUserCreationService;
 import uk.gov.ida.saml.core.domain.AuthnContext;
-import uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement;
 import uk.gov.ida.saml.core.domain.UnknownUserCreationIdaStatus;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.test.builders.SimpleMdsValueBuilder;
 
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
@@ -51,7 +47,7 @@ public class UnknownUserAttributeQueryHandlerTest {
     private AssertionLifetimeConfiguration assertionLifetimeConfiguration;
 
     @Mock
-    private AdapterToMatchingServiceProxy adapterToMatchingServiceProxy;
+    private MatchingServiceProxy matchingServiceProxy;
 
     @Mock
     private UserIdHashFactory userIdHashFactory;
@@ -65,37 +61,37 @@ public class UnknownUserAttributeQueryHandlerTest {
         when(assertionLifetimeConfiguration.getAssertionLifetime()).thenReturn(Duration.days(2));
         unknownUserAttributeQueryHandler = new UnknownUserAttributeQueryHandler(
             userIdHashFactory, configuration,
-                assertionFactory,
-                assertionLifetimeConfiguration,
-                adapterToMatchingServiceProxy,
-                new UserAccountCreationAttributeExtractor());
+            assertionFactory,
+            assertionLifetimeConfiguration,
+            matchingServiceProxy,
+            new UserAccountCreationAttributeExtractor());
         when(userIdHashFactory.hashId(anyString(), anyString(), anyObject())).thenReturn(hashedPid);
     }
 
     @Test
     public void shouldReturnSuccessResponseWhenMatchingServiceReturnsSuccess() {
         InboundMatchingServiceRequest inboundMatchingServiceRequest = anInboundMatchingServiceRequest()
-                .withAuthnStatementAssertion(
-                        anIdentityProviderAssertion()
-                                .withAuthnStatement(anIdentityProviderAuthnStatement().withAuthnContext(AuthnContext.LEVEL_1).build())
-                                .build()
-                )
-                .withUserCreationAttributes(ImmutableList.of(FIRST_NAME))
-                .withMatchingDatasetAssertion(
-                        anIdentityProviderAssertion()
-                                .withMatchingDataset(
-                                        aMatchingDataset().addFirstname(
-                                                SimpleMdsValueBuilder.<String>aSimpleMdsValue()
-                                                        .withValue("name")
-                                                        .withFrom(null)
-                                                        .withTo(null)
-                                                        .build())
-                                        .build())
-                                .build()
-                )
-                .build();
-        when(adapterToMatchingServiceProxy.makeUnknownUserCreationRequest(new UnknownUserCreationRequestDto(hashedPid, LevelOfAssuranceDto.LEVEL_1)))
-                .thenReturn(new UnknownUserCreationResponseDto(SUCCESS));
+            .withAuthnStatementAssertion(
+                anIdentityProviderAssertion()
+                    .withAuthnStatement(anIdentityProviderAuthnStatement().withAuthnContext(AuthnContext.LEVEL_1).build())
+                    .build()
+            )
+            .withUserCreationAttributes(ImmutableList.of(FIRST_NAME))
+            .withMatchingDatasetAssertion(
+                anIdentityProviderAssertion()
+                    .withMatchingDataset(
+                        aMatchingDataset().addFirstname(
+                            SimpleMdsValueBuilder.<String>aSimpleMdsValue()
+                                .withValue("name")
+                                .withFrom(null)
+                                .withTo(null)
+                                .build())
+                            .build())
+                    .build()
+            )
+            .build();
+        when(matchingServiceProxy.makeUnknownUserCreationRequest(new UnknownUserCreationRequestDto(hashedPid, LevelOfAssuranceDto.LEVEL_1)))
+            .thenReturn(new UnknownUserCreationResponseDto(SUCCESS));
 
         OutboundResponseFromUnknownUserCreationService response = unknownUserAttributeQueryHandler.handle(inboundMatchingServiceRequest);
         assertThat(response.getStatus()).isEqualTo(UnknownUserCreationIdaStatus.Success);
@@ -104,14 +100,14 @@ public class UnknownUserAttributeQueryHandlerTest {
     @Test
     public void shouldReturnFailureResponseWhenMatchingServiceReturnsFailure() {
         InboundMatchingServiceRequest inboundMatchingServiceRequest = anInboundMatchingServiceRequest()
-                .withAuthnStatementAssertion(
-                        anIdentityProviderAssertion()
-                                .withAuthnStatement(anIdentityProviderAuthnStatement().withAuthnContext(AuthnContext.LEVEL_2).build())
-                                .build()
-                )
-                .build();
-        when(adapterToMatchingServiceProxy.makeUnknownUserCreationRequest(new UnknownUserCreationRequestDto(hashedPid, LevelOfAssuranceDto.LEVEL_2)))
-                .thenReturn(new UnknownUserCreationResponseDto(FAILURE));
+            .withAuthnStatementAssertion(
+                anIdentityProviderAssertion()
+                    .withAuthnStatement(anIdentityProviderAuthnStatement().withAuthnContext(AuthnContext.LEVEL_2).build())
+                    .build()
+            )
+            .build();
+        when(matchingServiceProxy.makeUnknownUserCreationRequest(new UnknownUserCreationRequestDto(hashedPid, LevelOfAssuranceDto.LEVEL_2)))
+            .thenReturn(new UnknownUserCreationResponseDto(FAILURE));
 
         OutboundResponseFromUnknownUserCreationService handle = unknownUserAttributeQueryHandler.handle(inboundMatchingServiceRequest);
         assertThat(handle.getStatus()).isEqualTo(UnknownUserCreationIdaStatus.CreateFailure);

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserAttributeQueryHandlerTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserAttributeQueryHandlerTest.java
@@ -18,11 +18,17 @@ import uk.gov.ida.matchingserviceadapter.saml.UserIdHashFactory;
 import uk.gov.ida.matchingserviceadapter.saml.transformers.inbound.InboundMatchingServiceRequest;
 import uk.gov.ida.matchingserviceadapter.saml.transformers.outbound.OutboundResponseFromUnknownUserCreationService;
 import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement;
 import uk.gov.ida.saml.core.domain.UnknownUserCreationIdaStatus;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.test.builders.SimpleMdsValueBuilder;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.matchingserviceadapter.builders.InboundMatchingServiceRequestBuilder.anInboundMatchingServiceRequest;
 import static uk.gov.ida.matchingserviceadapter.domain.UserAccountCreationAttribute.FIRST_NAME;
@@ -39,9 +45,6 @@ public class UnknownUserAttributeQueryHandlerTest {
     private MatchingServiceAdapterConfiguration configuration;
 
     @Mock
-    UserIdHashFactory hashFactory;
-
-    @Mock
     private MatchingServiceAssertionFactory assertionFactory;
 
     @Mock
@@ -49,6 +52,9 @@ public class UnknownUserAttributeQueryHandlerTest {
 
     @Mock
     private AdapterToMatchingServiceProxy adapterToMatchingServiceProxy;
+
+    @Mock
+    private UserIdHashFactory userIdHashFactory;
 
     private UnknownUserAttributeQueryHandler unknownUserAttributeQueryHandler;
 
@@ -58,12 +64,12 @@ public class UnknownUserAttributeQueryHandlerTest {
     public void setup() {
         when(assertionLifetimeConfiguration.getAssertionLifetime()).thenReturn(Duration.days(2));
         unknownUserAttributeQueryHandler = new UnknownUserAttributeQueryHandler(
-                hashFactory,
-                configuration,
+            userIdHashFactory, configuration,
                 assertionFactory,
                 assertionLifetimeConfiguration,
                 adapterToMatchingServiceProxy,
                 new UserAccountCreationAttributeExtractor());
+        when(userIdHashFactory.hashId(anyString(), anyString(), anyObject())).thenReturn(hashedPid);
     }
 
     @Test
@@ -88,11 +94,6 @@ public class UnknownUserAttributeQueryHandlerTest {
                                 .build()
                 )
                 .build();
-        when(hashFactory.createHashedId(
-                inboundMatchingServiceRequest.getMatchingDatasetAssertion().getIssuerId(),
-                configuration.getEntityId(),
-                inboundMatchingServiceRequest.getMatchingDatasetAssertion().getPersistentId().getNameId(),
-                inboundMatchingServiceRequest.getAuthnStatementAssertion().getAuthnStatement())).thenReturn(hashedPid);
         when(adapterToMatchingServiceProxy.makeUnknownUserCreationRequest(new UnknownUserCreationRequestDto(hashedPid, LevelOfAssuranceDto.LEVEL_1)))
                 .thenReturn(new UnknownUserCreationResponseDto(SUCCESS));
 
@@ -109,11 +110,6 @@ public class UnknownUserAttributeQueryHandlerTest {
                                 .build()
                 )
                 .build();
-        when(hashFactory.createHashedId(
-                inboundMatchingServiceRequest.getMatchingDatasetAssertion().getIssuerId(),
-                configuration.getEntityId(),
-                inboundMatchingServiceRequest.getMatchingDatasetAssertion().getPersistentId().getNameId(),
-                inboundMatchingServiceRequest.getAuthnStatementAssertion().getAuthnStatement())).thenReturn(hashedPid);
         when(adapterToMatchingServiceProxy.makeUnknownUserCreationRequest(new UnknownUserCreationRequestDto(hashedPid, LevelOfAssuranceDto.LEVEL_2)))
                 .thenReturn(new UnknownUserCreationResponseDto(FAILURE));
 

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/controllogic/UserIdHashFactoryTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/controllogic/UserIdHashFactoryTest.java
@@ -1,7 +1,10 @@
 package uk.gov.ida.matchingserviceadapter.controllogic;
 
 import com.google.common.base.Optional;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ida.matchingserviceadapter.saml.UserIdHashFactory;
@@ -17,13 +20,20 @@ import static uk.gov.ida.saml.core.test.builders.PersistentIdBuilder.aPersistent
 
 @RunWith(MockitoJUnitRunner.class)
 public class UserIdHashFactoryTest {
+
+    private static final String MSA_ENTITY_ID = "entity";
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private UserIdHashFactory userIdHashFactory = new UserIdHashFactory(MSA_ENTITY_ID);
+
     @Test
     public void createHashedId_shouldCallMessageDigest() throws Exception {
         final PersistentId persistentId = aPersistentId().build();
-        final String partnerEntityId = "partner";
-        final String entityId = "entity";
+        final String issuerId = "partner";
 
-        final String hashedId = new UserIdHashFactory().createHashedId(partnerEntityId, entityId, persistentId.getNameId(), Optional.of(IdentityProviderAuthnStatement.createIdentityProviderAuthnStatement(AuthnContext.LEVEL_2, new IpAddress("ipaddress"))));
+        final String hashedId = userIdHashFactory.hashId(issuerId, persistentId.getNameId(), Optional.of(IdentityProviderAuthnStatement.createIdentityProviderAuthnStatement(AuthnContext.LEVEL_2, new IpAddress("ipaddress"))).transform(IdentityProviderAuthnStatement::getAuthnContext));
 
         assertThat(hashedId).isEqualTo("a5fbea969c3837a712cbe9e188804796828f369106478e623a436fa07e8fd298");
     }
@@ -34,13 +44,19 @@ public class UserIdHashFactoryTest {
         final String partnerEntityId = "partner";
         final String entityId = "entity";
 
-        final UserIdHashFactory userIdHashFactory = new UserIdHashFactory();
-
         final long numberOfUniqueGeneratedHashedPids = Arrays.stream(AuthnContext.values())
-                .map(authnContext -> userIdHashFactory.createHashedId(partnerEntityId, entityId, persistentId.getNameId(), Optional.of(IdentityProviderAuthnStatement.createIdentityProviderAuthnStatement(authnContext, new IpAddress("ipaddress")))))
+                .map(authnContext -> userIdHashFactory.hashId(partnerEntityId, persistentId.getNameId(), Optional.of(IdentityProviderAuthnStatement.createIdentityProviderAuthnStatement(authnContext, new IpAddress("ipaddress"))).transform(IdentityProviderAuthnStatement::getAuthnContext)))
                 .distinct()
                 .count();
 
         assertThat(numberOfUniqueGeneratedHashedPids).isEqualTo(5);
+    }
+
+    @Test
+    public void shouldThrowIfAuthnContextAbsent() {
+        exception.expect(IllegalStateException.class);
+        exception.expectMessage(String.format("Authn context absent for persistent id %s", "pid"));
+
+        userIdHashFactory.hashId("", "pid", Optional.absent());
     }
 }

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/healthcheck/MatchingServiceAdapterHealthCheckTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/healthcheck/MatchingServiceAdapterHealthCheckTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.matchingserviceadapter.healthcheck;
 
-import com.codahale.metrics.health.HealthCheck;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/mappers/InboundMatchingServiceRequestToMatchingServiceRequestDtoMapperTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/mappers/InboundMatchingServiceRequestToMatchingServiceRequestDtoMapperTest.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.matchingserviceadapter.mappers;
 
+import com.google.common.base.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,10 +34,10 @@ public class InboundMatchingServiceRequestToMatchingServiceRequestDtoMapperTest 
     public static final String ISSUER_ID = "issuerId";
 
     @Mock
-    MatchingServiceAdapterConfiguration matchingServiceAdapterConfiguration;
+    private MatchingServiceAdapterConfiguration matchingServiceAdapterConfiguration;
 
     @Mock
-    UserIdHashFactory hashFactory;
+    private UserIdHashFactory userIdHashFactory;
 
     @Mock
     private MatchingDatasetToMatchingDatasetDtoMapper matchingDatasetToMatchingDatasetDtoMapper;
@@ -45,7 +46,7 @@ public class InboundMatchingServiceRequestToMatchingServiceRequestDtoMapperTest 
 
     @Before
     public void setUp() throws Exception {
-        mapper = new InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper(hashFactory, matchingServiceAdapterConfiguration, matchingDatasetToMatchingDatasetDtoMapper);
+        mapper = new InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper(userIdHashFactory, matchingServiceAdapterConfiguration, matchingDatasetToMatchingDatasetDtoMapper);
     }
 
     @Test
@@ -74,13 +75,8 @@ public class InboundMatchingServiceRequestToMatchingServiceRequestDtoMapperTest 
         InboundMatchingServiceRequest request = anInboundMatchingServiceRequest()
                 .withMatchingDatasetAssertion(anIdentityProviderAssertion().withMatchingDataset(matchingDataset).build())
                 .build();
-
         String hashedPid = "a-hashed-pid";
-        when(matchingServiceAdapterConfiguration.getEntityId()).thenReturn(ISSUER_ID);
-        when(hashFactory.createHashedId(request.getMatchingDatasetAssertion().getIssuerId(),
-                ISSUER_ID,
-                request.getMatchingDatasetAssertion().getPersistentId().getNameId(), request.getAuthnStatementAssertion().getAuthnStatement()))
-                .thenReturn(hashedPid);
+        when(userIdHashFactory.hashId(request.getMatchingDatasetAssertion().getIssuerId(), request.getMatchingDatasetAssertion().getPersistentId().getNameId(), request.getAuthnStatementAssertion().getAuthnStatement().transform(IdentityProviderAuthnStatement::getAuthnContext))).thenReturn(hashedPid);
 
         MatchingServiceRequestDto requestDto = mapper.map(request);
 

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/proxies/MatchingServiceProxyImplTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/proxies/MatchingServiceProxyImplTest.java
@@ -22,7 +22,7 @@ import static uk.gov.ida.matchingserviceadapter.builders.UnknownUserCreationRequ
 import static uk.gov.ida.matchingserviceadapter.builders.UnknownUserCreationResponseDtoBuilder.anUnknownUserCreationResponseDto;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AdapterToMatchingServiceHttpProxyTest {
+public class MatchingServiceProxyImplTest {
 
     @Mock
     private JsonClient client;
@@ -30,11 +30,11 @@ public class AdapterToMatchingServiceHttpProxyTest {
     @Mock
     private MatchingServiceAdapterConfiguration configuration;
 
-    private AdapterToMatchingServiceHttpProxy proxy;
+    private MatchingServiceProxyImpl proxy;
 
     @Before
     public void setUp() {
-        proxy = new AdapterToMatchingServiceHttpProxy(client, configuration);
+        proxy = new MatchingServiceProxyImpl(client, configuration);
     }
 
     @Test

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/AttributeStatementBuilder.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/AttributeStatementBuilder.java
@@ -1,0 +1,136 @@
+package uk.gov.ida.matchingserviceadapter.services;
+
+import org.joda.time.LocalDate;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.extensions.eidas.BirthName;
+import uk.gov.ida.saml.core.extensions.eidas.CurrentFamilyName;
+import uk.gov.ida.saml.core.extensions.eidas.CurrentGivenName;
+import uk.gov.ida.saml.core.extensions.eidas.DateOfBirth;
+import uk.gov.ida.saml.core.extensions.eidas.Gender;
+import uk.gov.ida.saml.core.extensions.eidas.PersonIdentifier;
+import uk.gov.ida.saml.core.extensions.eidas.PlaceOfBirth;
+import uk.gov.ida.saml.core.extensions.eidas.impl.BirthNameBuilder;
+import uk.gov.ida.saml.core.extensions.eidas.impl.CurrentFamilyNameBuilder;
+import uk.gov.ida.saml.core.extensions.eidas.impl.CurrentGivenNameBuilder;
+import uk.gov.ida.saml.core.extensions.eidas.impl.DateOfBirthBuilder;
+import uk.gov.ida.saml.core.extensions.eidas.impl.GenderBuilder;
+import uk.gov.ida.saml.core.extensions.eidas.impl.PersonIdentifierBuilder;
+import uk.gov.ida.saml.core.extensions.eidas.impl.PlaceOfBirthBuilder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class AttributeStatementBuilder {
+
+    public static final String BIRTH_NAME="http://eidas.europa.eu/attributes/naturalperson/BirthName";
+    public static final String PLACE_OF_BIRTH="http://eidas.europa.eu/attributes/naturalperson/PlaceOfBirth";
+
+    private static OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private List<Attribute> attributes = new ArrayList<>();
+
+    public static AttributeStatementBuilder anAttributeStatement() {
+        return new AttributeStatementBuilder();
+    }
+
+    /**
+     * Retain original defaults to maintain backward compatibility with existing tests.
+     * @deprecated Use @link AttributeStatementBuilder#anEidasAttributeStatement(Attribute ... attributes) instead for future tests.
+     * @return
+     */
+    public static AttributeStatementBuilder anEidasAttributeStatement() {
+        return anEidasAttributeStatement(
+            aCurrentGivenNameAttribute("Joe"),
+            aCurrentFamilyNameAttribute("Bloggs"),
+            aPersonIdentifierAttribute("JB12345"),
+            aDateOfBirthAttribute(LocalDate.now()));
+    }
+
+    public static AttributeStatementBuilder anEidasAttributeStatement(Attribute ... attributes) {
+        return anAttributeStatement().addAllAttributes(attributes != null ? Arrays.asList(attributes) : Collections.emptyList());
+    }
+
+    public static Attribute aCurrentGivenNameAttribute(String givenName) {
+        Attribute firstNameAttr =  anAttribute(IdaConstants.Eidas_Attributes.FirstName.NAME);
+        CurrentGivenName firstNameValue = new CurrentGivenNameBuilder().buildObject();
+        firstNameValue.setFirstName(givenName);
+        firstNameAttr.getAttributeValues().add(firstNameValue);
+        return firstNameAttr;
+    }
+
+    public static Attribute aCurrentFamilyNameAttribute(String familyName) {
+        Attribute familyNameAttr =  anAttribute(IdaConstants.Eidas_Attributes.FamilyName.NAME);
+        CurrentFamilyName familyNameValue = new CurrentFamilyNameBuilder().buildObject();
+        familyNameValue.setFamilyName(familyName);
+        familyNameAttr.getAttributeValues().add(familyNameValue);
+        return familyNameAttr;
+    }
+
+    public static Attribute aPersonIdentifierAttribute(String personIdentifier) {
+        Attribute personIdentifierAttr =  anAttribute(IdaConstants.Eidas_Attributes.PersonIdentifier.NAME);
+        PersonIdentifier personIdentifierValue = new PersonIdentifierBuilder().buildObject();
+        personIdentifierValue.setPersonIdentifier(personIdentifier);
+        personIdentifierAttr.getAttributeValues().add(personIdentifierValue);
+        return personIdentifierAttr;
+    }
+
+    public static Attribute aDateOfBirthAttribute(LocalDate dateOfBirth) {
+        Attribute dateOfBirthAttr =  anAttribute(IdaConstants.Eidas_Attributes.DateOfBirth.NAME);
+        DateOfBirth dateOfBirthValue = new DateOfBirthBuilder().buildObject();
+        dateOfBirthValue.setDateOfBirth(dateOfBirth);
+        dateOfBirthAttr.getAttributeValues().add(dateOfBirthValue);
+        return dateOfBirthAttr;
+    }
+
+    public static Attribute aGenderAttribute(String gender) {
+        Attribute genderAttribute =  anAttribute(IdaConstants.Eidas_Attributes.Gender.NAME);
+        Gender genderValue = new GenderBuilder().buildObject();
+        genderValue.setValue(gender);
+        genderAttribute.getAttributeValues().add(genderValue);
+        return genderAttribute;
+    }
+
+    public static Attribute aBirthNameAttribute(String birthName) {
+        Attribute birthNameAttribute =  anAttribute(IdaConstants.Eidas_Attributes.BirthName.NAME);
+        BirthName birthNameValue = new BirthNameBuilder().buildObject();
+        birthNameValue.setBirthName(birthName);
+        birthNameAttribute.getAttributeValues().add(birthNameValue);
+        return birthNameAttribute;
+    }
+
+    public static Attribute aPlaceOfBirthAttribute(String placeOfBirth) {
+        Attribute placeOfBirthAttribute =  anAttribute(IdaConstants.Eidas_Attributes.PlaceOfBirth.NAME);
+        PlaceOfBirth placeOfBirthValue = new PlaceOfBirthBuilder().buildObject();
+        placeOfBirthValue.setPlaceOfBirth(placeOfBirth);
+        placeOfBirthAttribute.getAttributeValues().add(placeOfBirthValue);
+        return placeOfBirthAttribute;
+    }
+
+    private static Attribute anAttribute(String name) {
+        Attribute attribute = openSamlXmlObjectFactory.createAttribute();
+        attribute.setName(name);
+        return attribute;
+    }
+
+    public AttributeStatement build() {
+        AttributeStatement attributeStatement = openSamlXmlObjectFactory.createAttributeStatement();
+
+        attributeStatement.getAttributes().addAll(attributes);
+
+        return attributeStatement;
+    }
+
+    public AttributeStatementBuilder addAttribute(Attribute attribute) {
+        this.attributes.add(attribute);
+        return this;
+    }
+
+    public AttributeStatementBuilder addAllAttributes(List<Attribute> attributes) {
+        this.attributes.addAll(attributes);
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingRequestToLMSRequestTransformTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingRequestToLMSRequestTransformTest.java
@@ -1,0 +1,101 @@
+package uk.gov.ida.matchingserviceadapter.services;
+
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Assertion;
+import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceRequestContext;
+import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceRequestDto;
+import uk.gov.ida.matchingserviceadapter.rest.matchingservice.LevelOfAssuranceDto;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.hub.domain.LevelOfAssurance;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.aBirthNameAttribute;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.aCurrentFamilyNameAttribute;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.aCurrentGivenNameAttribute;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.aDateOfBirthAttribute;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.aGenderAttribute;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.aPersonIdentifierAttribute;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.aPlaceOfBirthAttribute;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.anEidasAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextBuilder.anAuthnContext;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder.anAuthnContextClassRef;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anAuthnStatement;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class EidasMatchingRequestToLMSRequestTransformTest {
+    public static final org.joda.time.LocalDate DOB = org.joda.time.LocalDate.parse("2001-02-01", ISODateTimeFormat.dateTimeParser());
+    private Assertion assertion;
+
+    private EidasMatchingRequestToLMSRequestTransform transform;
+
+    @Before
+    public void setUp() {
+        assertion = anAssertion()
+            .addAuthnStatement(
+                anAuthnStatement()
+                    .withAuthnContext(anAuthnContext()
+                        .withAuthnContextClassRef(
+                            anAuthnContextClassRef()
+                            .withAuthnContextClasRefValue(LevelOfAssurance.SUBSTANTIAL.toString())
+                            .build()
+                        ).build()
+                    )
+                .build()
+            )
+            .addAttributeStatement(
+                anEidasAttributeStatement(
+                    aCurrentGivenNameAttribute("Fred"),
+                    aCurrentFamilyNameAttribute("Flintstone"),
+                    aPersonIdentifierAttribute("the-pid"),
+                    aGenderAttribute("MALE"),
+                    aDateOfBirthAttribute(DOB),
+                    aBirthNameAttribute("birth-name"),
+                    aPlaceOfBirthAttribute("place-of-birth")
+                ).build()
+            ).buildUnencrypted();
+        transform = new EidasMatchingRequestToLMSRequestTransform();
+    }
+
+    @Test
+    public void shouldMapLoaCorrectly() {
+        MatchingServiceRequestContext request = new MatchingServiceRequestContext(null, null, asList(assertion));
+
+        MatchingServiceRequestDto lmsDto = transform.apply(request);
+
+        assertThat(lmsDto.getLevelOfAssurance(), notNullValue());
+        assertThat(lmsDto.getLevelOfAssurance().name(), equalTo(LevelOfAssuranceDto.LEVEL_2.name()));
+
+    }
+
+    @Test
+    public void shouldExtractPidCorrectly() throws Throwable {
+        MatchingServiceRequestContext request = new MatchingServiceRequestContext(null, null, asList(assertion));
+
+        MatchingServiceRequestDto lmsDto = transform.apply(request);
+
+        assertThat(lmsDto.getHashedPid(), equalTo("the-pid"));
+    }
+
+    @Test
+    public void shouldMapEidasMatchingDatasetCorrectly() {
+        MatchingServiceRequestContext request = new MatchingServiceRequestContext(null, null, asList(assertion));
+
+        MatchingServiceRequestDto lmsDto = transform.apply(request);
+
+        assertThat(lmsDto.getEidasDataset(), notNullValue());
+        assertThat(lmsDto.getEidasDataset().getFirstName(), equalTo("Fred"));
+        assertThat(lmsDto.getEidasDataset().getDateOfBirth(), equalTo(DOB));
+        assertThat(lmsDto.getEidasDataset().getFamilyName(), equalTo("Flintstone"));
+        assertThat(lmsDto.getEidasDataset().getGender(), equalTo("MALE"));
+        assertThat(lmsDto.getEidasDataset().getBirthName(), equalTo("birth-name"));
+        assertThat(lmsDto.getEidasDataset().getPlaceOfBirth(), equalTo("place-of-birth"));
+
+    }
+}

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingServiceTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingServiceTest.java
@@ -3,34 +3,49 @@ package uk.gov.ida.matchingserviceadapter.services;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.opensaml.saml.saml2.core.AttributeQuery;
 import org.w3c.dom.Document;
 import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceRequestContext;
+import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceRequestDto;
 import uk.gov.ida.validation.messages.Message;
 import uk.gov.ida.validation.messages.Messages;
 import uk.gov.ida.validation.validators.Validator;
 
 import java.util.Collections;
+import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.validation.messages.MessageImpl.globalMessage;
 import static uk.gov.ida.validation.messages.MessagesImpl.messages;
 
+
+@RunWith(MockitoJUnitRunner.class)
 public class EidasMatchingServiceTest {
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
+    @Mock
+    private Validator<AttributeQuery> validator;
+
+    @Mock
+    private Function<MatchingServiceRequestContext, MatchingServiceRequestDto> transformer;
+
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldUseValidatorSupplied() {
-        Validator<AttributeQuery> attributeQueryValidator = mock(Validator.class);
-        EidasMatchingService service = new EidasMatchingService(attributeQueryValidator);
+    public void serviceIsCreatedSucessfully() {
+        EidasMatchingService service = new EidasMatchingService(validator, transformer);
 
-        assertThat(service.getValidator(), sameInstance(attributeQueryValidator));
+        assertThat(service.getValidator(), sameInstance(validator));
+        assertThat(service.getTransformer(), sameInstance(transformer));
     }
 
     @Test
@@ -38,30 +53,31 @@ public class EidasMatchingServiceTest {
         Message validationErrorMessage = globalMessage("theValidationErrorCode", "handle failed with validation messages");
         exception.expectMessage("Eidas Attribute Query was invalid");
         exception.expectMessage(validationErrorMessage.getParameterisedMessage());
+        exception.expect(RuntimeException.class);
 
-        Validator<AttributeQuery> attributeQueryValidator = mock(Validator.class);
-        when(attributeQueryValidator.validate(any(AttributeQuery.class), any(Messages.class))).thenReturn(messages().addError(validationErrorMessage));
-        EidasMatchingService service = new EidasMatchingService(attributeQueryValidator);
+        when(validator.validate(any(AttributeQuery.class), any(Messages.class))).thenReturn(messages().addError(validationErrorMessage));
+        EidasMatchingService service = new EidasMatchingService(validator, transformer);
         Document attributeQueryDocument = mock(Document.class);
         AttributeQuery attributeQuery = mock(AttributeQuery.class);
+        MatchingServiceRequestContext request = new MatchingServiceRequestContext(attributeQueryDocument, attributeQuery, Collections.emptyList());
 
-        service.handle(new MatchingServiceRequestContext(attributeQueryDocument, attributeQuery, Collections.emptyList()));
-
-        assertThat(service.getValidator(), sameInstance(attributeQueryValidator));
+        service.handle(request);
     }
 
     @Test
     public void handleSuccessful() {
         exception.expectMessage(EidasMatchingService.TODO_MESSAGE);
 
-        Validator<AttributeQuery> attributeQueryValidator = mock(Validator.class);
-        when(attributeQueryValidator.validate(any(AttributeQuery.class), any(Messages.class))).thenReturn(messages());
-        EidasMatchingService service = new EidasMatchingService(attributeQueryValidator);
+        when(validator.validate(any(AttributeQuery.class), any(Messages.class))).thenReturn(messages());
+        EidasMatchingService service = new EidasMatchingService(validator, transformer);
         Document attributeQueryDocument = mock(Document.class);
         AttributeQuery attributeQuery = mock(AttributeQuery.class);
+        MatchingServiceRequestContext request = new MatchingServiceRequestContext(attributeQueryDocument, attributeQuery, Collections.emptyList());
 
-        service.handle(new MatchingServiceRequestContext(attributeQueryDocument, attributeQuery, Collections.emptyList()));
+        service.handle(request);
 
-        assertThat(service.getValidator(), sameInstance(attributeQueryValidator));
+        verify(validator).validate(attributeQuery, any(Messages.class));
+        verify(transformer).apply(request);
+        verifyNoMoreInteractions(validator, transformer);
     }
 }

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingServiceTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasMatchingServiceTest.java
@@ -1,83 +1,112 @@
 package uk.gov.ida.matchingserviceadapter.services;
 
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.AttributeQuery;
 import org.w3c.dom.Document;
 import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceRequestContext;
+import uk.gov.ida.matchingserviceadapter.domain.VerifyMatchingServiceResponse;
+import uk.gov.ida.matchingserviceadapter.exceptions.AttributeQueryValidationException;
+import uk.gov.ida.matchingserviceadapter.mappers.MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper;
+import uk.gov.ida.matchingserviceadapter.proxies.MatchingServiceProxy;
 import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceRequestDto;
+import uk.gov.ida.matchingserviceadapter.rest.MatchingServiceResponseDto;
+import uk.gov.ida.matchingserviceadapter.saml.transformers.outbound.OutboundResponseFromMatchingService;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.builders.AssertionBuilder;
+import uk.gov.ida.saml.core.test.builders.AttributeQueryBuilder;
 import uk.gov.ida.validation.messages.Message;
 import uk.gov.ida.validation.messages.Messages;
 import uk.gov.ida.validation.validators.Validator;
 
-import java.util.Collections;
 import java.util.function.Function;
 
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anEidasAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextBuilder.anAuthnContext;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder.anAuthnContextClassRef;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anAuthnStatement;
 import static uk.gov.ida.validation.messages.MessageImpl.globalMessage;
 import static uk.gov.ida.validation.messages.MessagesImpl.messages;
 
-
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(OpenSAMLMockitoRunner.class)
 public class EidasMatchingServiceTest {
+
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
     @Mock
+    private Document document;
+    @Mock
     private Validator<AttributeQuery> validator;
-
+    @Mock
+    private MatchingServiceRequestDto matchingServiceRequestDto;
+    @Mock
+    private MatchingServiceResponseDto matchingServiceResponseDto;
+    @Mock
+    OutboundResponseFromMatchingService outboundResponseFromMatchingService;
     @Mock
     private Function<MatchingServiceRequestContext, MatchingServiceRequestDto> transformer;
+    @Mock
+    private MatchingServiceProxy matchingServiceClient;
+    @Mock
+    private MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper responseMapper;
 
-    @SuppressWarnings("unchecked")
-    @Test
-    public void serviceIsCreatedSucessfully() {
-        EidasMatchingService service = new EidasMatchingService(validator, transformer);
+    private static final String PID = "pid";
+    private static final AttributeQuery ATTRIBUTE_QUERY = AttributeQueryBuilder.anAttributeQuery().build();
+    private static final Assertion ASSERTION = AssertionBuilder.anEidasAssertion().buildUnencrypted();
 
-        assertThat(service.getValidator(), sameInstance(validator));
-        assertThat(service.getTransformer(), sameInstance(transformer));
+    private EidasMatchingService service;
+    private MatchingServiceRequestContext request;
+
+    @Before
+    public void setup() {
+        service = new EidasMatchingService(validator, transformer, matchingServiceClient, responseMapper);
+        request = new MatchingServiceRequestContext(document, ATTRIBUTE_QUERY, ImmutableList.of(ASSERTION));
     }
 
     @Test
-    public void handleFailsAndReturnsValidationErrors() {
+    public void shouldReturnErrorsWhenValidationFails() {
         Message validationErrorMessage = globalMessage("theValidationErrorCode", "handle failed with validation messages");
         exception.expectMessage("Eidas Attribute Query was invalid");
         exception.expectMessage(validationErrorMessage.getParameterisedMessage());
-        exception.expect(RuntimeException.class);
-
+        exception.expect(AttributeQueryValidationException.class);
         when(validator.validate(any(AttributeQuery.class), any(Messages.class))).thenReturn(messages().addError(validationErrorMessage));
-        EidasMatchingService service = new EidasMatchingService(validator, transformer);
-        Document attributeQueryDocument = mock(Document.class);
-        AttributeQuery attributeQuery = mock(AttributeQuery.class);
-        MatchingServiceRequestContext request = new MatchingServiceRequestContext(attributeQueryDocument, attributeQuery, Collections.emptyList());
 
         service.handle(request);
     }
 
     @Test
-    public void handleSuccessful() {
-        exception.expectMessage(EidasMatchingService.TODO_MESSAGE);
+    public void shouldHandleValidAQR() {
+        when(validator.validate(eq(ATTRIBUTE_QUERY), any(Messages.class))).thenReturn(messages());
+        when(transformer.apply(request)).thenReturn(matchingServiceRequestDto);
+        when(matchingServiceClient.makeMatchingServiceRequest(matchingServiceRequestDto)).thenReturn(matchingServiceResponseDto);
+        when(matchingServiceRequestDto.getHashedPid()).thenReturn(PID);
+        when(responseMapper.map(matchingServiceResponseDto, PID, request.getAttributeQuery().getID(), request.getAttributeQuery().getSubject().getNameID().getNameQualifier(),
+            AuthnContext.LEVEL_2, request.getAttributeQuery().getSubject().getNameID().getSPNameQualifier()))
+            .thenReturn(outboundResponseFromMatchingService);
 
-        when(validator.validate(any(AttributeQuery.class), any(Messages.class))).thenReturn(messages());
-        EidasMatchingService service = new EidasMatchingService(validator, transformer);
-        Document attributeQueryDocument = mock(Document.class);
-        AttributeQuery attributeQuery = mock(AttributeQuery.class);
-        MatchingServiceRequestContext request = new MatchingServiceRequestContext(attributeQueryDocument, attributeQuery, Collections.emptyList());
+        VerifyMatchingServiceResponse response = (VerifyMatchingServiceResponse) service.handle(request);
 
-        service.handle(request);
-
-        verify(validator).validate(attributeQuery, any(Messages.class));
+        verify(validator).validate(eq(ATTRIBUTE_QUERY), any(Messages.class));
         verify(transformer).apply(request);
-        verifyNoMoreInteractions(validator, transformer);
+        verify(matchingServiceClient).makeMatchingServiceRequest(matchingServiceRequestDto);
+        verify(responseMapper).map(matchingServiceResponseDto, PID, request.getAttributeQuery().getID(), request.getAttributeQuery().getSubject().getNameID().getNameQualifier(),
+            AuthnContext.LEVEL_2, request.getAttributeQuery().getSubject().getNameID().getSPNameQualifier());
+        assertThat(response.getOutboundResponseFromMatchingService()).isEqualTo(outboundResponseFromMatchingService);
+        verifyNoMoreInteractions(validator, transformer, matchingServiceClient);
     }
+
 }

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validators/AttributeStatementValidatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validators/AttributeStatementValidatorTest.java
@@ -6,29 +6,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AttributeStatement;
-import uk.gov.ida.saml.core.IdaConstants;
-import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
-import uk.gov.ida.saml.core.extensions.eidas.CurrentFamilyName;
-import uk.gov.ida.saml.core.extensions.eidas.CurrentGivenName;
-import uk.gov.ida.saml.core.extensions.eidas.DateOfBirth;
-import uk.gov.ida.saml.core.extensions.eidas.Gender;
-import uk.gov.ida.saml.core.extensions.eidas.PersonIdentifier;
-import uk.gov.ida.saml.core.extensions.eidas.impl.CurrentFamilyNameBuilder;
-import uk.gov.ida.saml.core.extensions.eidas.impl.CurrentGivenNameBuilder;
-import uk.gov.ida.saml.core.extensions.eidas.impl.DateOfBirthBuilder;
-import uk.gov.ida.saml.core.extensions.eidas.impl.GenderBuilder;
-import uk.gov.ida.saml.core.extensions.eidas.impl.PersonIdentifierBuilder;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.validation.messages.Messages;
 import uk.gov.ida.validation.validators.Validator;
 
 import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.aCurrentFamilyNameAttribute;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.aCurrentGivenNameAttribute;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.aDateOfBirthAttribute;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.aGenderAttribute;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.aPersonIdentifierAttribute;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeStatementBuilder.anAttributeStatement;
 import static uk.gov.ida.matchingserviceadapter.validators.AttributeStatementValidator.ATTRIBUTE_STATEMENT_NOT_PRESENT;
 import static uk.gov.ida.matchingserviceadapter.validators.AttributeStatementValidator.DATE_OF_BIRTH_IN_FUTURE;
 import static uk.gov.ida.matchingserviceadapter.validators.MatchingElementValidator.NO_VALUE_MATCHING_FILTER;
 import static uk.gov.ida.matchingserviceadapter.validators.StringValidators.STRING_VALUE_NOT_ENUMERATED;
-import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
 import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anEidasAttributeStatement;
 import static uk.gov.ida.validation.messages.MessagesImpl.messages;
 
@@ -51,7 +44,7 @@ public class AttributeStatementValidatorTest {
 
     @Test
     public void shouldGenerateNoErrorsIfAttributeStatementIsValidAndHasGenderAttribute() {
-        Messages messages = validator.validate(anEidasAttributeStatement().addAttribute(genderAttribute("Male")).build(), messages());
+        Messages messages = validator.validate(anEidasAttributeStatement().addAttribute(aGenderAttribute("Male")).build(), messages());
 
         assertThat(messages.hasErrors()).isFalse();
     }
@@ -136,7 +129,7 @@ public class AttributeStatementValidatorTest {
             .addAttribute(familyNameAttribute())
             .addAttribute(personIdentifierAttribute())
             .addAttribute(dateOfBirthAttribute())
-            .addAttribute(genderAttribute("foo"))
+            .addAttribute(aGenderAttribute("foo"))
             .build();
 
         Messages messages = validator.validate(attributeStatement, messages());
@@ -145,53 +138,22 @@ public class AttributeStatementValidatorTest {
     }
 
     private Attribute firstNameAttribute() {
-        Attribute firstName =  anAttribute(IdaConstants.Eidas_Attributes.FirstName.NAME);
-        CurrentGivenName firstNameValue = new CurrentGivenNameBuilder().buildObject();
-        firstNameValue.setFirstName("Joe");
-        firstName.getAttributeValues().add(firstNameValue);
-        return firstName;
+        return aCurrentGivenNameAttribute("Joe");
     }
 
     private Attribute familyNameAttribute() {
-        Attribute familyName =  anAttribute(IdaConstants.Eidas_Attributes.FamilyName.NAME);
-        CurrentFamilyName familyNameValue = new CurrentFamilyNameBuilder().buildObject();
-        familyNameValue.setFamilyName("Bloggs");
-        familyName.getAttributeValues().add(familyNameValue);
-        return familyName;
+        return aCurrentFamilyNameAttribute("Bloggs");
     }
 
     private Attribute personIdentifierAttribute() {
-        Attribute personIdentifier =  anAttribute(IdaConstants.Eidas_Attributes.PersonIdentifier.NAME);
-        PersonIdentifier personIdentifierValue = new PersonIdentifierBuilder().buildObject();
-        personIdentifierValue.setPersonIdentifier("JB12345");
-        personIdentifier.getAttributeValues().add(personIdentifierValue);
-        return personIdentifier;
+        return aPersonIdentifierAttribute("JB12345");
     }
 
     private Attribute dateOfBirthAttribute(LocalDate dob) {
-        Attribute dateOfBirth =  anAttribute(IdaConstants.Eidas_Attributes.DateOfBirth.NAME);
-        DateOfBirth dateOfBirthValue = new DateOfBirthBuilder().buildObject();
-        dateOfBirthValue.setDateOfBirth(dob);
-        dateOfBirth.getAttributeValues().add(dateOfBirthValue);
-        return dateOfBirth;
-    }
-
-    private Attribute genderAttribute(String genderType) {
-        Attribute gender =  anAttribute(IdaConstants.Eidas_Attributes.Gender.NAME);
-        Gender genderValue = new GenderBuilder().buildObject();
-        genderValue.setValue(genderType);
-        gender.getAttributeValues().add(genderValue);
-        return gender;
+        return aDateOfBirthAttribute(dob);
     }
 
     private Attribute dateOfBirthAttribute() {
         return dateOfBirthAttribute(LocalDate.now());
     }
-
-    private Attribute anAttribute(String name) {
-        Attribute attribute = new OpenSamlXmlObjectFactory().createAttribute();
-        attribute.setName(name);
-        return attribute;
-    }
-
 }


### PR DESCRIPTION
Reapplied the following stories.

1. EID-296: Mapping eIDAS AttributeQuery to LMS Request DTO
2. EID-166: hash pid for eIDAS flow
3. EID-297: Retrieve match/no match response from LMS and respond to Hub 

Authors: @lamerexter @adityapahuja @dapovey @timwspence