### PR TITLE
BAU: fix time validation

### DIFF
--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
@@ -63,6 +63,10 @@ public class MatchingServiceAdapterConfiguration extends Configuration implement
 
     @Valid
     @JsonProperty
+    private long clockSkewInSeconds = 30;
+
+    @Valid
+    @JsonProperty
     private CountryConfiguration country;
 
     protected MatchingServiceAdapterConfiguration() {
@@ -83,6 +87,10 @@ public class MatchingServiceAdapterConfiguration extends Configuration implement
 
     public String getEntityId() {
         return matchingServiceAdapter.getEntityId();
+    }
+
+    public long getClockSkew() {
+        return clockSkewInSeconds;
     }
 
     public URI getLocalMatchingServiceMatchUrl() {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -230,7 +230,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
                     countryCertificateValidator.get(),
                     new CertificateExtractor(),
                     x509CertificateFactory,
-                    new DateTimeComparator(Duration.ZERO),
+                    new DateTimeComparator(Duration.standardSeconds(configuration.getClockSkew())),
                     assertionDecrypter,
                     configuration.getCountry().getHubConnectorEntityId()
                 ),

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ConditionsValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ConditionsValidator.java
@@ -21,7 +21,7 @@ public class ConditionsValidator<T> extends CompositeValidator<T> {
     public static final MessageImpl DEFAULT_NOT_BEFORE_MUST_BE_LESS_THAN_NOT_ON_OR_AFTER_TIME_MESSAGE = fieldMessage("conditions.invalid", "conditions.invalid", "The value for NotBefore MUST be less than (earlier than) the value for NotOnOrAfter.");
     public static final MessageImpl DEFAULT_CONDITIONS_MUST_CONTAIN_ONE_AUDIENCE_RESTRICTION_MESSAGE = globalMessage("conditions.audienceRestrictions.audienceRestriction", "There must be 1 audience restriction.");
 
-    public ConditionsValidator(final Function<T, Conditions> valueProvider, final String audienceUri) {
+    public ConditionsValidator(final Function<T, Conditions> valueProvider, final String audienceUri, final DateTimeComparator dateTimeComparator) {
         super(
             true,
             valueProvider,
@@ -30,12 +30,12 @@ public class ConditionsValidator<T> extends CompositeValidator<T> {
             new CompositeValidator<>(
                 conditions -> conditions.getNotBefore() != null && conditions.getNotOnOrAfter() != null,
                 false,
-                new FixedErrorValidator<>(conditions -> conditions.getNotOnOrAfter().isBefore(conditions.getNotOnOrAfter()) || conditions.getNotOnOrAfter().isEqual(conditions.getNotBefore()), DEFAULT_NOT_BEFORE_MUST_BE_LESS_THAN_NOT_ON_OR_AFTER_TIME_MESSAGE)
+                new FixedErrorValidator<>(conditions -> !conditions.getNotBefore().isBefore(conditions.getNotOnOrAfter()), DEFAULT_NOT_BEFORE_MUST_BE_LESS_THAN_NOT_ON_OR_AFTER_TIME_MESSAGE)
             ),
             new CompositeValidator<>(
                 conditions -> conditions.getNotBefore() != null,
                 false,
-                new FixedErrorValidator<>(conditions -> DateTime.now(DateTimeZone.UTC).isBefore(conditions.getNotBefore()), DEFAULT_CURRENT_TIME_BEFORE_VALID_TIME_MESSAGE)
+                new FixedErrorValidator<>(conditions -> !dateTimeComparator.isBeforeNow(conditions.getNotBefore()), DEFAULT_CURRENT_TIME_BEFORE_VALID_TIME_MESSAGE)
             ),
             new CompositeValidator<>(
                 conditions -> conditions.getNotOnOrAfter() != null,

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/DateTimeComparator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/DateTimeComparator.java
@@ -11,19 +11,15 @@ public class DateTimeComparator {
 
     private final Duration clockSkew;
 
-    public boolean isAfterFuzzy(DateTime source, DateTime target) {
-        return source.isAfter(target.minus(clockSkew));
-    }
-
-    public boolean isBeforeFuzzy(DateTime source, DateTime target) {
-        return source.isBefore(target.plus(clockSkew));
-    }
-
     public boolean isBeforeNow(DateTime dateTime) {
-        return !isBeforeFuzzy(DateTime.now(), dateTime);
+        return isBefore(dateTime, DateTime.now());
     }
 
     public boolean isAfterNow(DateTime dateTime) {
-        return !isAfterFuzzy(DateTime.now(), dateTime);
+        return isBefore(DateTime.now(), dateTime);
+    }
+
+    private boolean isBefore(DateTime dateTime, DateTime target) {
+        return dateTime.isBefore(target.plus(clockSkew));
     }
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/EidasAttributeQueryAssertionValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/EidasAttributeQueryAssertionValidator.java
@@ -65,7 +65,7 @@ public class EidasAttributeQueryAssertionValidator extends CompositeValidator<As
                 new FixedErrorValidator<>(a -> a.getAuthnStatements().size() != 1, generateWrongNumberOfAuthnStatementsMessage(typeOfAssertion)),
                 new AuthnStatementValidator<>(a -> a.getAuthnStatements().get(0), dateTimeComparator)
             ),
-            new ConditionsValidator<>(Assertion::getConditions, hubConnectorEntityId),
+            new ConditionsValidator<>(Assertion::getConditions, hubConnectorEntityId, dateTimeComparator),
             new CompositeValidator<>(
                 true,
                 new FixedErrorValidator<>(a -> a.getAttributeStatements().size() != 1 , generateWrongNumberOfAttributeStatementsMessage(typeOfAssertion)),

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validators/ConditionsValidatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validators/ConditionsValidatorTest.java
@@ -3,6 +3,7 @@ package uk.gov.ida.matchingserviceadapter.validators;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +33,7 @@ public class ConditionsValidatorTest {
     @Before
     public void setUp() throws Exception {
         DateTimeUtils.setCurrentMillisFixed(NOW.getMillis());
-        validator = new ConditionsValidator<>(conditions -> conditions, AUDIENCE_URI);
+        validator = new ConditionsValidator<>(conditions -> conditions, AUDIENCE_URI, new DateTimeComparator(Duration.standardSeconds(5)));
 
         audienceRestriction= new AudienceRestrictionBuilder().buildObject();
         Audience audience = new AudienceBuilder().buildObject();
@@ -65,9 +66,21 @@ public class ConditionsValidatorTest {
     }
 
     @Test
-    public void shouldReturnErrorIfNotBeforeIsNotMet() {
+    public void shouldNotReturnErrorIfNotBeforeIsCloseToNow() {
         Conditions conditions = new ConditionsBuilder().buildObject();
         conditions.setNotBefore(NOW.plusMillis(1));
+        conditions.getAudienceRestrictions().add(audienceRestriction);
+
+        Messages messages = validator.validate(conditions, messages());
+
+        assertThat(messages.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldReturnErrorIfNotBeforeIsDefinitelyNotMet() {
+        Conditions conditions = new ConditionsBuilder().buildObject();
+        conditions.setNotBefore(NOW.plusSeconds(20));
+        conditions.getAudienceRestrictions().add(audienceRestriction);
 
         Messages messages = validator.validate(conditions, messages());
 

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validators/DateTimeComparatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validators/DateTimeComparatorTest.java
@@ -7,76 +7,46 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DateTimeComparatorTest {
-
-    private static final DateTime baseTime = new DateTime(2017, 1, 1, 12, 0);
     private static final DateTimeComparator comparator = new DateTimeComparator(Duration.standardSeconds(5));
 
     @Test
-    public void isAfterReturnsTrueWhenAIsAfterB() throws Exception {
-        DateTime newTime = baseTime.plusMinutes(1);
-
-        assertThat(comparator.isAfterFuzzy(newTime, baseTime)).isTrue();
-    }
-
-    @Test
-    public void isAfterReturnsFalseWhenAIsBeforeB() throws Exception {
-        DateTime newTime = baseTime.minusMinutes(1);
-
-        assertThat(comparator.isAfterFuzzy(newTime, baseTime)).isFalse();
-    }
-
-    @Test
-    public void isAfterReturnsTrueWhenAIsWithinSkewOfB() throws Exception {
-        DateTime newTime = baseTime.minusSeconds(4);
-
-        assertThat(comparator.isAfterFuzzy(newTime, baseTime)).isTrue();
-    }
-
-    @Test
-    public void isBeforeReturnsTrueWhenAIsBeforeB() throws Exception {
-        DateTime newTime = baseTime.minusMinutes(1);
-
-        assertThat(comparator.isBeforeFuzzy(newTime, baseTime)).isTrue();
-    }
-
-    @Test
-    public void isBeforeReturnsFalseWhenAIsAfterB() throws Exception {
-        DateTime newTime = baseTime.plusMinutes(1);
-
-        assertThat(comparator.isBeforeFuzzy(newTime, baseTime)).isFalse();
-    }
-
-    @Test
-    public void isBeforeReturnsTrueWhenAIsWithinSkewOfB() throws Exception {
-        DateTime newTime = baseTime.plusSeconds(4);
-
-        assertThat(comparator.isBeforeFuzzy(newTime, baseTime)).isTrue();
-    }
-
-    @Test
     public void isBeforeNowReturnsTrueWhenInThePast() {
-        DateTime pastDateTime = new DateTime().minusMinutes(1);
+        DateTime pastDateTime = DateTime.now().minusMinutes(1);
 
         assertThat(comparator.isBeforeNow(pastDateTime)).isTrue();
     }
 
     @Test
-    public void isBeforeNowReturnsFalseWhenInThePast() {
-        DateTime dateTime = new DateTime().plusMillis(1);
+    public void isBeforeNowReturnsTrueWhenInTheFutureButLessThanTheSkew() {
+        DateTime dateTime = new DateTime().plusSeconds(1);
+
+        assertThat(comparator.isBeforeNow(dateTime)).isTrue();
+    }
+
+    @Test
+    public void isBeforeNowReturnsFalseWhenFarInTheFuture() {
+        DateTime dateTime = new DateTime().plusSeconds(10);
 
         assertThat(comparator.isBeforeNow(dateTime)).isFalse();
     }
 
     @Test
     public void isAfterNowReturnsTrueWhenInTheFuture() {
-        DateTime futureDateTime = new DateTime().plusMinutes(1);
+        DateTime futureDateTime = DateTime.now().plusMinutes(1);
 
         assertThat(comparator.isAfterNow(futureDateTime)).isTrue();
     }
 
     @Test
-    public void isAfterNowReturnsFalseWhenInThePast() {
-        DateTime pastDateTime = new DateTime().minusMillis(1);
+    public void isAfterNowReturnsTrueWhenInThePastButLessThanTheSkew() {
+        DateTime pastDateTime = DateTime.now().minusSeconds(1);
+
+        assertThat(comparator.isAfterNow(pastDateTime)).isTrue();
+    }
+
+    @Test
+    public void isAfterNowReturnsFalseWhenFarInThePast() {
+        DateTime pastDateTime = DateTime.now().minusSeconds(10);
 
         assertThat(comparator.isAfterNow(pastDateTime)).isFalse();
     }


### PR DESCRIPTION
Fix fuzzy time matching so that IssueInstant validation passes despite small discrepancies in server time.
Make the 'clockSkew' an optional value in the app config, with a default value of 30 seconds. (As recommended by Richard)
Fix some of the NotBefore eIDAS validation.

Solo: @hugh-emerson