### PR TITLE
BAU: Use later version of hub-saml and verify-saml-libs with fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,10 @@ def dependencyVersions = [
         dropwizard: '1.1.4',
         ida_utils: '326',
         ida_test_utils: '35',
-        hub_saml: "$opensaml-120",
+        hub_saml: "$opensaml-121",
         dev_pki: '1.1.0-21',
         trust_anchor: '1.0-19',
-        saml_libs_version: "$opensaml-104"
+        saml_libs_version: "$opensaml-108"
 ]
 
 apply plugin: "idaJar"

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -82,6 +82,7 @@ import uk.gov.ida.saml.metadata.ExpiredCertificateMetadataFilter;
 import uk.gov.ida.saml.metadata.MetadataConfiguration;
 import uk.gov.ida.saml.metadata.TrustStoreConfiguration;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
+import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
 import uk.gov.ida.saml.metadata.transformers.KeyDescriptorsUnmarshaller;
 import uk.gov.ida.saml.security.AssertionDecrypter;
 import uk.gov.ida.saml.security.CertificateChainEvaluableCriterion;
@@ -234,7 +235,6 @@ class MatchingServiceAdapterModule extends AbstractModule {
             new EidasMatchingService(
                 new EidasAttributeQueryValidatorFactory(
                     verifyMetadataResolver,
-                    verifyCertificateValidator,
                     x509CertificateFactory,
                     configuration,
                     assertionDecrypter,
@@ -517,7 +517,8 @@ class MatchingServiceAdapterModule extends AbstractModule {
                     environment,
                     configuration.getEuropeanIdentity().getAggregatedMetadata(),
                     new DropwizardMetadataResolverFactory(),
-                    new Timer());
+                    new Timer(),
+                    new MetadataSignatureTrustEngineFactory());
             environment.healthChecks().register("TrustAnchorHealthCheck", new EidasTrustAnchorHealthCheck(resolverRepository));
             return Optional.of(resolverRepository);
         }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/factories/EidasAttributeQueryValidatorFactory.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/factories/EidasAttributeQueryValidatorFactory.java
@@ -6,30 +6,27 @@ import org.opensaml.saml.saml2.core.AttributeQuery;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.matchingserviceadapter.MatchingServiceAdapterConfiguration;
 import uk.gov.ida.matchingserviceadapter.repositories.CertificateExtractor;
-import uk.gov.ida.matchingserviceadapter.repositories.CertificateValidator;
 import uk.gov.ida.matchingserviceadapter.validators.DateTimeComparator;
 import uk.gov.ida.matchingserviceadapter.validators.EidasAttributeQueryValidator;
+import uk.gov.ida.matchingserviceadapter.validators.exceptions.SamlResponseValidationException;
 import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
 import uk.gov.ida.saml.security.AssertionDecrypter;
 import uk.gov.ida.validation.validators.Validator;
 
 public class EidasAttributeQueryValidatorFactory {
     private final MetadataResolver verifyMetadataResolver;
-    private final CertificateValidator verifyCertificateValidator;
     private final X509CertificateFactory x509CertificateFactory;
     private final MatchingServiceAdapterConfiguration configuration;
     private final AssertionDecrypter assertionDecrypter;
     private final EidasMetadataResolverRepository eidasMetadataResolverRepository;
 
     public EidasAttributeQueryValidatorFactory(MetadataResolver verifyMetadataResolver,
-                                               CertificateValidator verifyCertificateValidator,
                                                X509CertificateFactory x509CertificateFactory,
                                                MatchingServiceAdapterConfiguration configuration,
                                                AssertionDecrypter assertionDecrypter,
                                                EidasMetadataResolverRepository eidasMetadataResolverRepository) {
 
         this.verifyMetadataResolver = verifyMetadataResolver;
-        this.verifyCertificateValidator = verifyCertificateValidator;
         this.x509CertificateFactory = x509CertificateFactory;
         this.configuration = configuration;
         this.assertionDecrypter = assertionDecrypter;
@@ -39,7 +36,8 @@ public class EidasAttributeQueryValidatorFactory {
     public Validator<AttributeQuery> build(String issuerEntityId) {
         return new EidasAttributeQueryValidator(
                 verifyMetadataResolver,
-                eidasMetadataResolverRepository.getMetadataResolver(issuerEntityId),
+                eidasMetadataResolverRepository.getMetadataResolver(issuerEntityId).orElseThrow(() ->
+                        new SamlResponseValidationException("Unable to find metadata resolver for entity Id " + issuerEntityId)),
                 new CertificateExtractor(),
                 x509CertificateFactory,
                 new DateTimeComparator(Duration.standardSeconds(configuration.getClockSkew())),

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/EidasAttributesBasedAttributeQueryDiscriminator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/EidasAttributesBasedAttributeQueryDiscriminator.java
@@ -26,6 +26,6 @@ public class EidasAttributesBasedAttributeQueryDiscriminator implements Predicat
     }
 
     public boolean hasMetadataResolverForEntity(String entityId){
-        return eidasMetadataResolverRepository.getMetadataResolver(entityId) != null;
+        return eidasMetadataResolverRepository.getMetadataResolver(entityId).isPresent();
     }
 }


### PR DESCRIPTION
The newer version of verify-saml-libs have fixes to give metadata resolver unique names when adding them to the metric.