### PR TITLE
firebreak: use new signature validators for eidas assertions

### DIFF
--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/SamlDigitalSignatureValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/SamlDigitalSignatureValidator.java
@@ -32,6 +32,7 @@ import java.util.function.Predicate;
 
 import static uk.gov.ida.validation.messages.MessageImpl.globalMessage;
 
+@Deprecated
 public class SamlDigitalSignatureValidator<T extends SignableSAMLObject> extends CompositeValidator<T> {
 
     public static final MessageImpl DEFAULT_SAML_SIGNATURE_PROFILE_MESSAGE = globalMessage("saml.signature.profile", "Open SAML signature profile validation failed.");

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validators/EidasAttributeQueryAssertionValidatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validators/EidasAttributeQueryAssertionValidatorTest.java
@@ -1,13 +1,10 @@
 package uk.gov.ida.matchingserviceadapter.validators;
 
-import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Audience;
 import org.opensaml.saml.saml2.core.AudienceRestriction;
@@ -15,13 +12,11 @@ import org.opensaml.saml.saml2.core.Conditions;
 import org.opensaml.saml.saml2.core.impl.AudienceBuilder;
 import org.opensaml.saml.saml2.core.impl.AudienceRestrictionBuilder;
 import org.opensaml.saml.saml2.core.impl.ConditionsBuilder;
-import org.opensaml.saml.saml2.metadata.EntityDescriptor;
-import uk.gov.ida.common.shared.security.Certificate;
-import uk.gov.ida.common.shared.security.X509CertificateFactory;
-import uk.gov.ida.matchingserviceadapter.repositories.CertificateExtractor;
-import uk.gov.ida.matchingserviceadapter.repositories.CertificateValidator;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.core.test.TestCredentialFactory;
+import uk.gov.ida.saml.core.test.validators.SingleCertificateSignatureValidator;
+import uk.gov.ida.saml.security.SignatureValidator;
 import uk.gov.ida.validation.messages.Message;
 import uk.gov.ida.validation.messages.Messages;
 import uk.gov.ida.validation.validators.AbstractValidator;
@@ -33,14 +28,12 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
 import static uk.gov.ida.matchingserviceadapter.validators.AuthnStatementValidator.AUTHN_INSTANT_IN_FUTURE;
 import static uk.gov.ida.matchingserviceadapter.validators.EidasAttributeQueryAssertionValidator.generateEmptyIssuerMessage;
 import static uk.gov.ida.matchingserviceadapter.validators.EidasAttributeQueryAssertionValidator.generateWrongNumberOfAttributeStatementsMessage;
 import static uk.gov.ida.matchingserviceadapter.validators.EidasAttributeQueryAssertionValidator.generateWrongNumberOfAuthnStatementsMessage;
 import static uk.gov.ida.matchingserviceadapter.validators.MatchingElementValidator.NO_VALUE_MATCHING_FILTER;
 import static uk.gov.ida.matchingserviceadapter.validators.SubjectValidator.SUBJECT_NOT_PRESENT;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_ENTITY_ID;
 import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
 import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anEidasAssertion;
 import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
@@ -50,31 +43,19 @@ import static uk.gov.ida.validation.messages.MessagesImpl.messages;
 
 @RunWith(OpenSAMLMockitoRunner.class)
 public class EidasAttributeQueryAssertionValidatorTest {
-    @Mock
-    private MetadataResolver metadataResolver;
-
-    @Mock
-    private CertificateValidator certificateValidator;
-
-    @Mock
-    private CertificateExtractor certificateExtractor;
-
-    @Mock
-    private EntityDescriptor entityDescriptor;
+    private SignatureValidator signatureValidator;
 
     private static final String TYPE_OF_ASSERTION = "Identity";
     private static final String HUB_CONNECTOR_ENTITY_ID = "hubConnectorEntityId";
-    private X509CertificateFactory x509CertificateFactory = new X509CertificateFactory();
     private EidasAttributeQueryAssertionValidator validator;
     private static final Duration TTL = Duration.parse("PT999M");
     private static final Duration CLOCK_DELTA = Duration.parse("PT9M");
 
     @Before
     public void setUp() throws Exception {
+        signatureValidator = new SingleCertificateSignatureValidator(new TestCredentialFactory(TestCertificateStrings.TEST_PUBLIC_CERT, TestCertificateStrings.TEST_PRIVATE_KEY).getSigningCredential());
         validator = new EidasAttributeQueryAssertionValidator(
-            metadataResolver,
-            certificateExtractor,
-            x509CertificateFactory,
+            signatureValidator,
             new DateTimeComparator(org.joda.time.Duration.ZERO),
             TYPE_OF_ASSERTION,
             HUB_CONNECTOR_ENTITY_ID,
@@ -84,7 +65,6 @@ public class EidasAttributeQueryAssertionValidatorTest {
 
     @Test
     public void shouldValidateIssuer() throws Exception {
-        setUpCertificateValidation();
         Assertion assertion = anEidasAssertion().withIssuer(anIssuer().withIssuerId("").build()).buildUnencrypted();
 
         Messages messages = validator.validate(assertion, messages());
@@ -94,9 +74,6 @@ public class EidasAttributeQueryAssertionValidatorTest {
 
     @Test
     public void shouldValidateSubject() throws Exception {
-        when(metadataResolver.resolveSingle(any(CriteriaSet.class))).thenReturn(entityDescriptor);
-        when(certificateExtractor.extractIdpSigningCertificates(entityDescriptor))
-            .thenReturn(Arrays.asList(new Certificate(TEST_ENTITY_ID, TestCertificateStrings.TEST_PUBLIC_CERT, Certificate.KeyUse.Signing)));
         Assertion assertion = anAssertion().withSubject(null).buildUnencrypted();
 
         Messages messages = validator.validate(assertion, messages());
@@ -105,7 +82,6 @@ public class EidasAttributeQueryAssertionValidatorTest {
     }
 
     public void shouldGenerateErrorIfWrongNumberOfAttributeStatements() throws Exception {
-        setUpCertificateValidation();
         Assertion assertion = anEidasAssertion().addAttributeStatement(anAttributeStatement().build()).withConditions(aConditions()).buildUnencrypted();
 
         Messages messages = validator.validate(assertion, messages());
@@ -116,7 +92,6 @@ public class EidasAttributeQueryAssertionValidatorTest {
 
     @Test
     public void shouldValidateAttributeStatement() throws Exception {
-        setUpCertificateValidation();
         Assertion assertion = anAssertion()
             .addAttributeStatement(anAttributeStatement()
                 .build())
@@ -129,7 +104,6 @@ public class EidasAttributeQueryAssertionValidatorTest {
 
     @Test
     public void shouldValidateSignature() throws Exception {
-        setUpCertificateValidation();
         Assertion assertion = anEidasAssertion().withConditions(aConditions()).buildUnencrypted();
 
         Messages messages = validator.validate(assertion, messages());
@@ -168,10 +142,6 @@ public class EidasAttributeQueryAssertionValidatorTest {
 
     @Test
     public void shouldGenerateErrorIfThereIsMoreThanOneAuthnStatement() throws Exception {
-        when(metadataResolver.resolveSingle(any(CriteriaSet.class))).thenReturn(entityDescriptor);
-        when(certificateExtractor.extractIdpSigningCertificates(entityDescriptor))
-            .thenReturn(Arrays.asList(new Certificate(TEST_ENTITY_ID, TestCertificateStrings.TEST_PUBLIC_CERT, Certificate.KeyUse.Signing)));
-
         Assertion assertion = anAssertion()
             .addAuthnStatement(anAuthnStatement().build())
             .addAuthnStatement(anAuthnStatement().build())
@@ -184,10 +154,6 @@ public class EidasAttributeQueryAssertionValidatorTest {
 
     @Test
     public void shouldGenerateErrorIfThereAreNoAuthnStatements() throws Exception {
-        when(metadataResolver.resolveSingle(any(CriteriaSet.class))).thenReturn(entityDescriptor);
-        when(certificateExtractor.extractIdpSigningCertificates(entityDescriptor))
-            .thenReturn(Arrays.asList(new Certificate(TEST_ENTITY_ID, TestCertificateStrings.TEST_PUBLIC_CERT, Certificate.KeyUse.Signing)));
-
         Assertion assertion = anAssertion().buildUnencrypted();
 
         Messages messages = validator.validate(assertion, messages());
@@ -197,10 +163,6 @@ public class EidasAttributeQueryAssertionValidatorTest {
 
     @Test
     public void shouldValidateAuthnStatement() throws Exception {
-        when(metadataResolver.resolveSingle(any(CriteriaSet.class))).thenReturn(entityDescriptor);
-        when(certificateExtractor.extractIdpSigningCertificates(entityDescriptor))
-            .thenReturn(Arrays.asList(new Certificate(TEST_ENTITY_ID, TestCertificateStrings.TEST_PUBLIC_CERT, Certificate.KeyUse.Signing)));
-
         Assertion assertion = anAssertion()
             .addAuthnStatement(anAuthnStatement().withAuthnInstant(DateTime.now().plusMinutes(10)).build())
             .buildUnencrypted();
@@ -212,18 +174,11 @@ public class EidasAttributeQueryAssertionValidatorTest {
 
     @Test
     public void shouldValidateConditions() throws Exception {
-        setUpCertificateValidation();
         Assertion assertion = anAssertion().withConditions(null).buildUnencrypted();
 
         Messages messages = validator.validate(assertion, messages());
 
         assertThat(messages.hasErrorLike(ConditionsValidator.DEFAULT_REQUIRED_MESSAGE)).isTrue();
-    }
-
-    private void setUpCertificateValidation() throws Exception {
-        when(metadataResolver.resolveSingle(any(CriteriaSet.class))).thenReturn(entityDescriptor);
-        when(certificateExtractor.extractIdpSigningCertificates(entityDescriptor))
-            .thenReturn(Arrays.asList(new Certificate(TEST_ENTITY_ID, TestCertificateStrings.TEST_PUBLIC_CERT, Certificate.KeyUse.Signing)));
     }
 
     private Conditions aConditions() {


### PR DESCRIPTION
Uses the new SignatureTrustEngine support from saml-metadata-bindings
 for verifying the signatures of eIDAS Assertions.