### PR TITLE
EID-452: Choose MatchingAssertionUnmarshaller based on EidasMetadata …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ def dependencyVersions = [
         hub_saml: "$opensaml-123",
         dev_pki: '1.1.0-22',
         trust_anchor: '1.0-21',
-        saml_libs_version: "$opensaml-119"
+        saml_libs_version: "$opensaml-122"
 ]
 
 apply plugin: "idaJar"

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -143,7 +143,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private MetadataBackedEncryptionCredentialResolver hubEncryptionCredentialResolver(MetadataCredentialResolver metadataCredentialResolver) {
+    public MetadataBackedEncryptionCredentialResolver hubEncryptionCredentialResolver(MetadataCredentialResolver metadataCredentialResolver) {
         return new MetadataBackedEncryptionCredentialResolver(metadataCredentialResolver, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
@@ -155,13 +155,13 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private UserIdHashFactory getUserIdHashFactory(MatchingServiceAdapterConfiguration configuration) {
+    public UserIdHashFactory getUserIdHashFactory(MatchingServiceAdapterConfiguration configuration) {
         return new UserIdHashFactory(configuration.getEntityId());
     }
 
     @Provides
     @Singleton
-    private InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper getInboundMatchingServiceRequestToMatchingServiceRequestDtoMapper(
+    public InboundMatchingServiceRequestToMatchingServiceRequestDtoMapper getInboundMatchingServiceRequestToMatchingServiceRequestDtoMapper(
             UserIdHashFactory userIdHashFactory,
             MatchingDatasetToMatchingDatasetDtoMapper matchingDatasetToMatchingDatasetDtoMapper,
             MatchingServiceAdapterConfiguration configuration) {
@@ -397,7 +397,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private Function<OutboundResponseFromMatchingService, Element> getOutboundResponseFromMatchingServiceToElementTransformer(
+    public Function<OutboundResponseFromMatchingService, Element> getOutboundResponseFromMatchingServiceToElementTransformer(
             MetadataBackedEncryptionCredentialResolver encryptionCredentialResolver,
             IdaKeyStore idaKeyStore,
             EntityToEncryptForLocator entityToEncryptForLocator,
@@ -413,7 +413,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private Function<OutboundResponseFromUnknownUserCreationService, Element> getOutboundResponseFromUnknownUserCreationServiceToElementTransformer(
+    public Function<OutboundResponseFromUnknownUserCreationService, Element> getOutboundResponseFromUnknownUserCreationServiceToElementTransformer(
             MetadataBackedEncryptionCredentialResolver encryptionCredentialResolver,
             IdaKeyStore idaKeyStore,
             EntityToEncryptForLocator entityToEncryptForLocator,
@@ -429,13 +429,13 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private ElementToOpenSamlXMLObjectTransformer<AttributeQuery> getAttributeQueryTransformer() {
+    public ElementToOpenSamlXMLObjectTransformer<AttributeQuery> getAttributeQueryTransformer() {
         return new CoreTransformersFactory().getElementToOpenSamlXmlObjectTransformer();
     }
 
     @Provides
     @Singleton
-    private Function<AttributeQuery, InboundVerifyMatchingServiceRequest> getVerifyAttributeQueryToInboundMatchingServiceRequestTransformer(
+    public Function<AttributeQuery, InboundVerifyMatchingServiceRequest> getVerifyAttributeQueryToInboundMatchingServiceRequestTransformer(
             MetadataBackedSignatureValidator metadataBackedSignatureValidator,
             IdaKeyStore keyStore,
             MatchingServiceAdapterConfiguration matchingServiceAdapterConfiguration,
@@ -459,19 +459,19 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private ElementToOpenSamlXMLObjectTransformer<EntityDescriptor> getMetadataForSpTransformer() {
+    public ElementToOpenSamlXMLObjectTransformer<EntityDescriptor> getMetadataForSpTransformer() {
         return new CoreTransformersFactory().getElementToOpenSamlXmlObjectTransformer();
     }
 
     @Provides
     @Singleton
-    private KeyDescriptorsUnmarshaller getCertificatesToKeyDescriptorsTransformer() {
+    public KeyDescriptorsUnmarshaller getCertificatesToKeyDescriptorsTransformer() {
         return new CoreTransformersFactory().getCertificatesToKeyDescriptorsTransformer();
     }
 
     @Provides
     @Singleton
-    private Function<EntitiesDescriptor, Element> getEntityDescriptorToElementTransformer() {
+    public Function<EntitiesDescriptor, Element> getEntityDescriptorToElementTransformer() {
         return new CoreTransformersFactory().getXmlObjectToElementTransformer();
     }
 
@@ -507,7 +507,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private EidasTrustAnchorResolver getEidasTrustAnchorResolver(Environment environment, MatchingServiceAdapterConfiguration configuration) {
+    public EidasTrustAnchorResolver getEidasTrustAnchorResolver(Environment environment, MatchingServiceAdapterConfiguration configuration) {
         if (configuration.isEidasEnabled()) {
             EidasMetadataConfiguration metadataConfiguration = configuration.getEuropeanIdentity().getAggregatedMetadata();
 
@@ -525,7 +525,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private MetadataResolverRepository getEidasMetadataResolverRepository(
+    public MetadataResolverRepository getEidasMetadataResolverRepository(
             Environment environment,
             MatchingServiceAdapterConfiguration configuration,
             @Nullable EidasTrustAnchorResolver trustAnchorResolver) {
@@ -546,7 +546,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private HubAssertionExtractor getHubAssertionExtractor(@Named("HubEntityId") String hubEntityId) {
+    public HubAssertionExtractor getHubAssertionExtractor(@Named("HubEntityId") String hubEntityId) {
         return new HubAssertionExtractor(hubEntityId, new CoreTransformersFactory().getAssertionToHubAssertionTransformer(hubEntityId));
     }
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserAttributeQueryHandler.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserAttributeQueryHandler.java
@@ -59,14 +59,6 @@ public class UnknownUserAttributeQueryHandler {
     }
 
     public OutboundResponseFromUnknownUserCreationService createNewVerifyAccount(InboundVerifyMatchingServiceRequest attributeQuery) {
-        return createAccount(attributeQuery, userAccountCreationAttributeExtractor);
-    }
-
-    public OutboundResponseFromUnknownUserCreationService createNewEidasAccount(InboundVerifyMatchingServiceRequest attributeQuery) {
-        return createAccount(attributeQuery, userEidasAccountCreationAttributeExtractor);
-    }
-
-    private OutboundResponseFromUnknownUserCreationService createAccount(InboundVerifyMatchingServiceRequest attributeQuery, UserAccountCreationAttributeExtractor extractor) {
         IdentityProviderAssertion matchingDatasetAssertion = attributeQuery.getMatchingDatasetAssertion();
         IdentityProviderAssertion authnStatementAssertion = attributeQuery.getAuthnStatementAssertion();
         final String hashedPid = userIdHashFactory.hashId(matchingDatasetAssertion.getIssuerId(),
@@ -82,7 +74,7 @@ public class UnknownUserAttributeQueryHandler {
         Optional<MatchingDataset> matchingDataset = attributeQuery.getMatchingDatasetAssertion().getMatchingDataset();
 
         List<Attribute> extractedUserAccountCreationAttributes =
-                extractor.getUserAccountCreationAttributes(
+                userAccountCreationAttributeExtractor.getUserAccountCreationAttributes(
                                 attributeQuery.getUserCreationAttributes(),
                         matchingDataset.orElse(null), attributeQuery.getCycle3AttributeAssertion().orElse(null)
                 );

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserAttributeQueryHandler.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserAttributeQueryHandler.java
@@ -55,7 +55,7 @@ public class UnknownUserAttributeQueryHandler {
         this.userAccountCreationAttributeExtractor = userAccountCreationAttributeExtractor;
     }
 
-    public OutboundResponseFromUnknownUserCreationService createNewVerifyAccount(InboundVerifyMatchingServiceRequest attributeQuery) {
+    public OutboundResponseFromUnknownUserCreationService createAccount(InboundVerifyMatchingServiceRequest attributeQuery) {
         IdentityProviderAssertion matchingDatasetAssertion = attributeQuery.getMatchingDatasetAssertion();
         IdentityProviderAssertion authnStatementAssertion = attributeQuery.getAuthnStatementAssertion();
         final String hashedPid = userIdHashFactory.hashId(matchingDatasetAssertion.getIssuerId(),

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserAttributeQueryHandler.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserAttributeQueryHandler.java
@@ -38,7 +38,6 @@ public class UnknownUserAttributeQueryHandler {
     private final AssertionLifetimeConfiguration assertionLifetimeConfiguration;
     private final MatchingServiceProxy matchingServiceProxy;
     private final UserAccountCreationAttributeExtractor userAccountCreationAttributeExtractor;
-    private final UserAccountCreationAttributeExtractor userEidasAccountCreationAttributeExtractor;
 
     @Inject
     public UnknownUserAttributeQueryHandler(
@@ -54,8 +53,6 @@ public class UnknownUserAttributeQueryHandler {
         this.assertionLifetimeConfiguration = assertionLifetimeConfiguration;
         this.matchingServiceProxy = matchingServiceProxy;
         this.userAccountCreationAttributeExtractor = userAccountCreationAttributeExtractor;
-        userEidasAccountCreationAttributeExtractor = userAccountCreationAttributeExtractor;
-        //TODO Eidas specific version
     }
 
     public OutboundResponseFromUnknownUserCreationService createNewVerifyAccount(InboundVerifyMatchingServiceRequest attributeQuery) {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/factories/EidasAttributeQueryValidatorFactory.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/factories/EidasAttributeQueryValidatorFactory.java
@@ -2,14 +2,12 @@ package uk.gov.ida.matchingserviceadapter.factories;
 
 import org.joda.time.Duration;
 import org.opensaml.saml.saml2.core.AttributeQuery;
-import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.matchingserviceadapter.MatchingServiceAdapterConfiguration;
-import uk.gov.ida.matchingserviceadapter.repositories.CertificateExtractor;
 import uk.gov.ida.matchingserviceadapter.saml.HubAssertionExtractor;
 import uk.gov.ida.matchingserviceadapter.validators.DateTimeComparator;
 import uk.gov.ida.matchingserviceadapter.validators.EidasAttributeQueryValidator;
 import uk.gov.ida.matchingserviceadapter.validators.exceptions.SamlResponseValidationException;
-import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
+import uk.gov.ida.saml.metadata.MetadataResolverRepository;
 import uk.gov.ida.saml.security.AssertionDecrypter;
 import uk.gov.ida.saml.security.MetadataBackedSignatureValidator;
 import uk.gov.ida.saml.security.SignatureValidator;
@@ -20,13 +18,13 @@ public class EidasAttributeQueryValidatorFactory {
     private final MatchingServiceAdapterConfiguration configuration;
     private final AssertionDecrypter assertionDecrypter;
     private final HubAssertionExtractor hubAssertionExtractor;
-    private final EidasMetadataResolverRepository eidasMetadataResolverRepository;
+    private final MetadataResolverRepository eidasMetadataResolverRepository;
 
     public EidasAttributeQueryValidatorFactory(SignatureValidator verifySignatureValidator,
                                                MatchingServiceAdapterConfiguration configuration,
                                                AssertionDecrypter assertionDecrypter,
                                                HubAssertionExtractor hubAssertionExtractor,
-                                               EidasMetadataResolverRepository eidasMetadataResolverRepository) {
+                                               MetadataResolverRepository eidasMetadataResolverRepository) {
 
         this.verifySignatureValidator = verifySignatureValidator;
         this.configuration = configuration;

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/resources/UnknownUserAttributeQueryResource.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/resources/UnknownUserAttributeQueryResource.java
@@ -65,7 +65,7 @@ public class UnknownUserAttributeQueryResource {
     private OutboundResponseFromUnknownUserCreationService getOutboundResponseFromMatchingService(InboundVerifyMatchingServiceRequest hubMatchingServiceRequest) {
         OutboundResponseFromUnknownUserCreationService response;
         try {
-            response = attributeQueryHandler.createNewVerifyAccount(hubMatchingServiceRequest);
+            response = attributeQueryHandler.createAccount(hubMatchingServiceRequest);
         } catch (WebApplicationException e) {
             throw new SamlOverSoapException("The matching service returned a http error.", e, hubMatchingServiceRequest.getId());
         }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/EidasAttributesBasedAttributeQueryDiscriminator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/EidasAttributesBasedAttributeQueryDiscriminator.java
@@ -3,15 +3,15 @@ package uk.gov.ida.matchingserviceadapter.saml.transformers.inbound.transformers
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Issuer;
 import uk.gov.ida.matchingserviceadapter.domain.MatchingServiceRequestContext;
-import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
+import uk.gov.ida.saml.metadata.MetadataResolverRepository;
 
 import java.util.Objects;
 import java.util.function.Predicate;
 
 public class EidasAttributesBasedAttributeQueryDiscriminator implements Predicate<MatchingServiceRequestContext> {
-    private final EidasMetadataResolverRepository eidasMetadataResolverRepository;
+    private final MetadataResolverRepository eidasMetadataResolverRepository;
 
-    public EidasAttributesBasedAttributeQueryDiscriminator(EidasMetadataResolverRepository eidasMetadataResolverRepository) {
+    public EidasAttributesBasedAttributeQueryDiscriminator(MetadataResolverRepository eidasMetadataResolverRepository) {
         this.eidasMetadataResolverRepository = eidasMetadataResolverRepository;
     }
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/VerifyAttributeQueryToInboundMatchingServiceRequestTransformer.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/VerifyAttributeQueryToInboundMatchingServiceRequestTransformer.java
@@ -53,7 +53,6 @@ public class VerifyAttributeQueryToInboundMatchingServiceRequestTransformer impl
     }
 
     public InboundVerifyMatchingServiceRequest apply(final AttributeQuery attributeQuery) {
-        String issuerId = attributeQuery.getIssuer().getValue();
         samlAttributeQueryValidator.validate(attributeQuery);
         ValidatedAttributeQuery validatedAttributeQuery = attributeQuerySignatureValidator.validate(attributeQuery);
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/VerifyAttributeQueryToInboundMatchingServiceRequestTransformer.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/VerifyAttributeQueryToInboundMatchingServiceRequestTransformer.java
@@ -7,7 +7,6 @@ import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import uk.gov.ida.matchingserviceadapter.saml.security.AttributeQuerySignatureValidator;
 import uk.gov.ida.matchingserviceadapter.saml.security.ValidatedAttributeQuery;
-import uk.gov.ida.matchingserviceadapter.saml.transformers.inbound.InboundMatchingServiceRequest;
 import uk.gov.ida.matchingserviceadapter.saml.transformers.inbound.InboundVerifyMatchingServiceRequest;
 import uk.gov.ida.matchingserviceadapter.saml.transformers.inbound.decorators.SamlAttributeQueryAssertionsValidator;
 import uk.gov.ida.matchingserviceadapter.saml.transformers.inbound.decorators.SamlAttributeQueryValidator;
@@ -27,7 +26,9 @@ public class VerifyAttributeQueryToInboundMatchingServiceRequestTransformer impl
     private final SamlAttributeQueryValidator samlAttributeQueryValidator;
     private final AttributeQuerySignatureValidator attributeQuerySignatureValidator;
     private final SamlAssertionsSignatureValidator samlAssertionsSignatureValidator;
+
     private final InboundMatchingServiceRequestUnmarshaller inboundMatchingServiceRequestUnmarshaller;
+
     private final SamlAttributeQueryAssertionsValidator samlAttributeQueryAssertionsValidator;
     private final AssertionDecrypter assertionDecrypter;
     private final String hubEntityId;
@@ -52,6 +53,7 @@ public class VerifyAttributeQueryToInboundMatchingServiceRequestTransformer impl
     }
 
     public InboundVerifyMatchingServiceRequest apply(final AttributeQuery attributeQuery) {
+        String issuerId = attributeQuery.getIssuer().getValue();
         samlAttributeQueryValidator.validate(attributeQuery);
         ValidatedAttributeQuery validatedAttributeQuery = attributeQuerySignatureValidator.validate(attributeQuery);
 
@@ -66,7 +68,7 @@ public class VerifyAttributeQueryToInboundMatchingServiceRequestTransformer impl
 
         ValidatedAssertions validatedHubAssertions = samlAssertionsSignatureValidator.validate(hubAssertions, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
         ValidatedAssertions validatedIdpAssertions = samlAssertionsSignatureValidator.validate(idpAssertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
-        return inboundMatchingServiceRequestUnmarshaller.fromSaml(validatedAttributeQuery, validatedHubAssertions, validatedIdpAssertions);
+        return this.inboundMatchingServiceRequestUnmarshaller.fromSaml(validatedAttributeQuery, validatedHubAssertions, validatedIdpAssertions);
     }
 
     private boolean isHubAssertion(Assertion assertion) {

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserAttributeQueryHandlerTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserAttributeQueryHandlerTest.java
@@ -79,7 +79,7 @@ public class UnknownUserAttributeQueryHandlerTest {
         when(matchingServiceProxy.makeUnknownUserCreationRequest(new UnknownUserCreationRequestDto(hashedPid, levelOfAssuranceDto)))
             .thenReturn(new UnknownUserCreationResponseDto(SUCCESS));
 
-        OutboundResponseFromUnknownUserCreationService response = unknownUserAttributeQueryHandler.createNewVerifyAccount(buildInboundVerifyMatchingServiceRequest());
+        OutboundResponseFromUnknownUserCreationService response = unknownUserAttributeQueryHandler.createAccount(buildInboundVerifyMatchingServiceRequest());
 
         assertThat(response.getStatus()).isEqualTo(UnknownUserCreationIdaStatus.Success);
     }
@@ -89,7 +89,7 @@ public class UnknownUserAttributeQueryHandlerTest {
         when(matchingServiceProxy.makeUnknownUserCreationRequest(new UnknownUserCreationRequestDto(hashedPid, levelOfAssuranceDto)))
             .thenReturn(new UnknownUserCreationResponseDto(FAILURE));
 
-        OutboundResponseFromUnknownUserCreationService handle = unknownUserAttributeQueryHandler.createNewVerifyAccount(buildInboundVerifyMatchingServiceRequest());
+        OutboundResponseFromUnknownUserCreationService handle = unknownUserAttributeQueryHandler.createAccount(buildInboundVerifyMatchingServiceRequest());
 
         assertThat(handle.getStatus()).isEqualTo(UnknownUserCreationIdaStatus.CreateFailure);
     }

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/domain/VerifyUserAccountCreationAttributeExtractorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/domain/VerifyUserAccountCreationAttributeExtractorTest.java
@@ -36,7 +36,7 @@ import static uk.gov.ida.matchingserviceadapter.domain.UserAccountCreationAttrib
 import static uk.gov.ida.matchingserviceadapter.domain.UserAccountCreationAttribute.SURNAME_VERIFIED;
 
 @RunWith(OpenSAMLRunner.class)
-public class UserAccountCreationAttributeExtractorTest {
+public class VerifyUserAccountCreationAttributeExtractorTest {
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/InboundMatchingServiceRequestUnmarshallerTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/InboundMatchingServiceRequestUnmarshallerTest.java
@@ -93,7 +93,7 @@ public class InboundMatchingServiceRequestUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldTransformAttributeQueryId() {
+    public void shouldTransformAttributeQueryId() {
         AttributeQuery query = givenAValidAttributeQuery();
 
         InboundMatchingServiceRequest transformedQuery = unmarshaller.fromSaml(
@@ -105,7 +105,7 @@ public class InboundMatchingServiceRequestUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldTransformAttributeQueryIssueInstant() {
+    public void shouldTransformAttributeQueryIssueInstant() {
         DateTimeFreezer.freezeTime();
 
         AttributeQuery query = givenAValidAttributeQuery();
@@ -121,7 +121,7 @@ public class InboundMatchingServiceRequestUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldMapIssuerId() {
+    public void shouldMapIssuerId() {
         AttributeQuery query = givenAValidAttributeQuery();
 
         InboundMatchingServiceRequest transformedQuery = unmarshaller.fromSaml(
@@ -133,7 +133,7 @@ public class InboundMatchingServiceRequestUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldMapAssertions() {
+    public void shouldMapAssertions() {
         AttributeQuery query = givenAValidAttributeQuery();
 
         InboundVerifyMatchingServiceRequest transformedQuery = unmarshaller.fromSaml(
@@ -150,7 +150,7 @@ public class InboundMatchingServiceRequestUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldMapAttributes() {
+    public void shouldMapAttributes() {
         AttributeQuery query = givenAValidAttributeQuery();
         InboundVerifyMatchingServiceRequest transformedQuery = unmarshaller.fromSaml(
                 new ValidatedAttributeQuery(query),

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/InboundMatchingServiceRequestUnmarshallerTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/saml/transformers/inbound/transformers/InboundMatchingServiceRequestUnmarshallerTest.java
@@ -27,15 +27,18 @@ import uk.gov.ida.saml.core.test.TestEntityIds;
 import uk.gov.ida.saml.core.transformers.IdentityProviderAssertionUnmarshaller;
 import uk.gov.ida.saml.core.transformers.inbound.HubAssertionUnmarshaller;
 import uk.gov.ida.saml.hub.factories.AttributeFactory_1_1;
+import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
 import uk.gov.ida.saml.security.validators.ValidatedAssertions;
 import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.jodatime.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.matchingserviceadapter.builders.MatchingDatasetBuilder.aMatchingDataset;
 import static uk.gov.ida.saml.core.test.builders.Cycle3DatasetBuilder.aCycle3Dataset;
@@ -58,11 +61,15 @@ public class InboundMatchingServiceRequestUnmarshallerTest {
     @Mock
     private IdentityProviderAssertionUnmarshaller identityProviderAssertionUnmarshaller;
 
+    @Mock
+    private EidasMetadataResolverRepository eidasMetadataResolverRepository;
+
     @Before
     public void setup() {
         unmarshaller = new InboundMatchingServiceRequestUnmarshaller(
                 hubAssertionUnmarshaller,
-                identityProviderAssertionUnmarshaller);
+                identityProviderAssertionUnmarshaller,
+                eidasMetadataResolverRepository);
 
         final IdentityProviderAssertion matchingDatasetAssertion = anIdentityProviderAssertion()
                 .withId(matchingDatasetAssertionId)
@@ -79,13 +86,14 @@ public class InboundMatchingServiceRequestUnmarshallerTest {
                 .withCycle3Data(aCycle3Dataset().addCycle3Data("name", "value").build())
                 .build();
 
-        when(identityProviderAssertionUnmarshaller.fromAssertion(any(Assertion.class))).thenReturn(matchingDatasetAssertion, authnStatementAssertion);
+        when(identityProviderAssertionUnmarshaller.fromVerifyAssertion(any(Assertion.class))).thenReturn(matchingDatasetAssertion, authnStatementAssertion);
         when(hubAssertionUnmarshaller.toHubAssertion(any(Assertion.class))).thenReturn(cycle3DataMatchAssertion);
+        when(eidasMetadataResolverRepository.getMetadataResolver(anyString())).thenReturn(Optional.empty());
         openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
     }
 
     @Test
-    public void transform_shouldTransformAttributeQueryId() throws Exception {
+    public void transform_shouldTransformAttributeQueryId() {
         AttributeQuery query = givenAValidAttributeQuery();
 
         InboundMatchingServiceRequest transformedQuery = unmarshaller.fromSaml(
@@ -97,7 +105,7 @@ public class InboundMatchingServiceRequestUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldTransformAttributeQueryIssueInstant() throws Exception {
+    public void transform_shouldTransformAttributeQueryIssueInstant() {
         DateTimeFreezer.freezeTime();
 
         AttributeQuery query = givenAValidAttributeQuery();
@@ -113,7 +121,7 @@ public class InboundMatchingServiceRequestUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldMapIssuerId() throws Exception {
+    public void transform_shouldMapIssuerId() {
         AttributeQuery query = givenAValidAttributeQuery();
 
         InboundMatchingServiceRequest transformedQuery = unmarshaller.fromSaml(
@@ -125,7 +133,7 @@ public class InboundMatchingServiceRequestUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldMapAssertions() throws Exception {
+    public void transform_shouldMapAssertions() {
         AttributeQuery query = givenAValidAttributeQuery();
 
         InboundVerifyMatchingServiceRequest transformedQuery = unmarshaller.fromSaml(


### PR DESCRIPTION
…entity.

    Within InboundMatchingServiceRequestUnmarshaller we now have an eidas MetadataResolverRepository. This checks if a given assertions issuer is a known eidas source. If it is, it uses an eidas unmarshaller for extracting attribute values from the attribute query, else it defaults to the standard verify model.

-Remove optional chain on Eidas objects in Guice injection (Module class).

    This also requires that we add a number of checks that eidas is enabled on config, and that a null object is passed if not. In the future, when eidas is enabled for good, we should remove this feature toggle and ensure that eidas objects are always created (i.e. non-null) by removing the @Nullable flags on the injections.

Co-authored-by: Kerr Rainey <kerr.rainey@digital.cabinet-office.gov.uk>