### PR TITLE
EID-584: Update saml-libs to latests version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ def dependencyVersions = [
         hub_saml: "$opensaml-15546",
         dev_pki: '1.1.0-22',
         trust_anchor: '1.0-21',
-        saml_libs_version: "$opensaml-126"
+        saml_libs_version: "$opensaml-128"
 ]
 
 apply plugin: "idaJar"

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -78,6 +78,7 @@ import uk.gov.ida.saml.metadata.MetadataConfiguration;
 import uk.gov.ida.saml.metadata.MetadataResolverConfigBuilder;
 import uk.gov.ida.saml.metadata.MetadataResolverRepository;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
+import uk.gov.ida.saml.metadata.factories.MetadataClientFactory;
 import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
 import uk.gov.ida.saml.metadata.transformers.KeyDescriptorsUnmarshaller;
 import uk.gov.ida.saml.security.AssertionDecrypter;
@@ -482,7 +483,9 @@ class MatchingServiceAdapterModule extends AbstractModule {
                     new DropwizardMetadataResolverFactory(),
                     new Timer(),
                     new MetadataSignatureTrustEngineFactory(),
-                    new MetadataResolverConfigBuilder());
+                    new MetadataResolverConfigBuilder(),
+                    new MetadataClientFactory()
+                );
             environment.healthChecks().register("TrustAnchorHealthCheck", new EidasTrustAnchorHealthCheck(resolverRepository));
             return resolverRepository;
         }


### PR DESCRIPTION
Includes changes to modify Eidas Metadata Resolvers to use a single
client between all resolvers and only update necessary Resolvers upon
refresh.