### PR TITLE
VCU-35: Make SHA level for signing messages configurable

### DIFF
--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
@@ -67,6 +67,10 @@ public class MatchingServiceAdapterConfiguration extends Configuration implement
     @JsonProperty
     private EuropeanIdentityConfiguration europeanIdentity;
 
+    @Valid
+    @JsonProperty
+    private boolean shouldSignWithSHA1 = false;
+
     protected MatchingServiceAdapterConfiguration() {
     }
 
@@ -138,6 +142,10 @@ public class MatchingServiceAdapterConfiguration extends Configuration implement
 
     public EuropeanIdentityConfiguration getEuropeanIdentity() {
         return europeanIdentity;
+    }
+
+    public boolean shouldSignWithSHA1() {
+        return shouldSignWithSHA1;
     }
 
     public static JerseyClientConfiguration getDefaultJerseyClientConfiguration(boolean verifyHostname, boolean trustSelfSignedCertificates) {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -334,7 +334,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
             EntityToEncryptForLocator entityToEncryptForLocator,
             MatchingServiceAdapterConfiguration configuration
     ) {
-        return new MsaTransformersFactory().getHealthcheckResponseFromMatchingServiceToElementTransformer(
+        return new MsaTransformersFactory(configuration).getHealthcheckResponseFromMatchingServiceToElementTransformer(
                 encryptionCredentialResolver,
                 idaKeyStore,
                 entityToEncryptForLocator,
@@ -350,7 +350,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
             EntityToEncryptForLocator entityToEncryptForLocator,
             MatchingServiceAdapterConfiguration configuration
     ) {
-        return new MsaTransformersFactory().getOutboundResponseFromMatchingServiceToElementTransformer(
+        return new MsaTransformersFactory(configuration).getOutboundResponseFromMatchingServiceToElementTransformer(
                 encryptionCredentialResolver,
                 idaKeyStore,
                 entityToEncryptForLocator,
@@ -366,7 +366,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
             EntityToEncryptForLocator entityToEncryptForLocator,
             MatchingServiceAdapterConfiguration configuration
     ) {
-        return new MsaTransformersFactory().getOutboundResponseFromUnknownUserCreationServiceToElementTransformer(
+        return new MsaTransformersFactory(configuration).getOutboundResponseFromUnknownUserCreationServiceToElementTransformer(
                 encryptionCredentialResolver,
                 idaKeyStore,
                 entityToEncryptForLocator,
@@ -385,13 +385,13 @@ class MatchingServiceAdapterModule extends AbstractModule {
     public Function<AttributeQuery, InboundVerifyMatchingServiceRequest> getVerifyAttributeQueryToInboundMatchingServiceRequestTransformer(
             MetadataBackedSignatureValidator metadataBackedSignatureValidator,
             IdaKeyStore keyStore,
-            MatchingServiceAdapterConfiguration matchingServiceAdapterConfiguration,
+            MatchingServiceAdapterConfiguration configuration,
             MetadataResolverRepository eidasMetadataResolverRepository,
             @Named("HubEntityId") String hubEntityId) {
-        return new MsaTransformersFactory().getVerifyAttributeQueryToInboundMatchingServiceRequestTransformer(
+        return new MsaTransformersFactory(configuration).getVerifyAttributeQueryToInboundMatchingServiceRequestTransformer(
                 metadataBackedSignatureValidator,
                 keyStore,
-                matchingServiceAdapterConfiguration,
+                configuration,
                 eidasMetadataResolverRepository,
                 hubEntityId
         );

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/saml/api/MsaTransformersFactory.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/saml/api/MsaTransformersFactory.java
@@ -3,8 +3,10 @@ package uk.gov.ida.matchingserviceadapter.saml.api;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
 import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA256;
 import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA1;
+import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA256;
 import org.w3c.dom.Element;
 import uk.gov.ida.matchingserviceadapter.MatchingServiceAdapterConfiguration;
 import uk.gov.ida.matchingserviceadapter.domain.HealthCheckResponseFromMatchingService;
@@ -66,9 +68,11 @@ import java.util.function.Function;
 @SuppressWarnings("unused")
 public class MsaTransformersFactory {
     private CoreTransformersFactory coreTransformersFactory;
+    private MatchingServiceAdapterConfiguration configuration;
 
-    public MsaTransformersFactory() {
+    public MsaTransformersFactory(MatchingServiceAdapterConfiguration configuration) {
         coreTransformersFactory = new CoreTransformersFactory();
+        this.configuration = configuration;
     }
 
     public ResponseToElementTransformer getResponseToElementTransformer(
@@ -77,9 +81,13 @@ public class MsaTransformersFactory {
             EntityToEncryptForLocator entityToEnryptForLocator,
             MatchingServiceAdapterConfiguration configuration
     ) {
+        SignatureAlgorithm signatureAlgorithm = configuration.shouldSignWithSHA1() ?
+                new SignatureRSASHA1() :
+                new SignatureRSASHA256();
+
         SignatureFactory signatureFactory = new SignatureFactory(
             new IdaKeyStoreCredentialRetriever(keyStore),
-            new SignatureRSASHA1(),
+            signatureAlgorithm,
             new DigestSHA256()
         );
         SamlResponseAssertionEncrypter assertionEncrypter = new SamlResponseAssertionEncrypter(


### PR DESCRIPTION
Solo: @alan-gds

Update the MSA to sign with SHA256 by default.
Configuration option provided to revert to SHA1 if required.