### PR TITLE
BAU: Fixed code analysis warnings.

### DIFF
--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterApplication.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterApplication.java
@@ -1,8 +1,7 @@
 package uk.gov.ida.matchingserviceadapter;
 
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.google.common.base.Throwables;
 import com.google.inject.AbstractModule;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
 import com.squarespace.jersey2.guice.JerseyGuiceUtils;
@@ -38,7 +37,11 @@ public class MatchingServiceAdapterApplication extends Application<MatchingServi
         // - it's the same fix that was required in the tests...
         JerseyGuiceUtils.reset();
 
-        new MatchingServiceAdapterApplication().runRuntimeException(args);
+        try {
+            new MatchingServiceAdapterApplication().run(args);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
@@ -89,7 +92,7 @@ public class MatchingServiceAdapterApplication extends Application<MatchingServi
     public final void run(MatchingServiceAdapterConfiguration configuration, Environment environment) {
         IdaSamlBootstrap.bootstrap();
 
-        environment.getObjectMapper().setDateFormat(new ISO8601DateFormat());
+        environment.getObjectMapper().setDateFormat(StdDateFormat.getDateInstance());
 
         environment.jersey().register(LocalMetadataResource.class);
         environment.jersey().register(MatchingServiceResource.class);
@@ -105,11 +108,4 @@ public class MatchingServiceAdapterApplication extends Application<MatchingServi
         environment.healthChecks().register(healthCheck.getName(), healthCheck);
     }
 
-    private void runRuntimeException(String[] arguments) {
-        try {
-            run(arguments);
-        } catch (Exception e) {
-            throw Throwables.propagate(e);
-        }
-    }
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/domain/OutboundResponseFromMatchingService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/domain/OutboundResponseFromMatchingService.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.matchingserviceadapter.domain;
 
 import org.joda.time.DateTime;
-import uk.gov.ida.common.shared.security.IdGenerator;
 import uk.gov.ida.saml.core.domain.IdaMatchingServiceResponse;
 import uk.gov.ida.saml.core.domain.MatchingServiceIdaStatus;
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/domain/OutboundResponseFromUnknownUserCreationService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/domain/OutboundResponseFromUnknownUserCreationService.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.matchingserviceadapter.domain;
 
 import org.joda.time.DateTime;
-import uk.gov.ida.common.shared.security.IdGenerator;
 import uk.gov.ida.saml.core.domain.IdaMatchingServiceResponse;
 import uk.gov.ida.saml.core.domain.UnknownUserCreationIdaStatus;
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/domain/UserAccountCreationAttribute.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/domain/UserAccountCreationAttribute.java
@@ -12,7 +12,6 @@ import uk.gov.ida.saml.core.domain.SimpleMdsValue;
 import uk.gov.ida.saml.core.domain.TransliterableMdsValue;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/SamlOverSoapExceptionMapper.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/SamlOverSoapExceptionMapper.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.matchingserviceadapter.exceptions;
 
-import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.xmlsec.signature.support.SignatureException;
@@ -42,7 +41,7 @@ public class SamlOverSoapExceptionMapper implements ExceptionMapper<SamlOverSoap
             return Response.serverError().entity(soapMessage).type(MediaType.TEXT_XML_TYPE).build();
         } catch (MarshallingException | SignatureException e) {
             LOG.error("Failed to create error response.");
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/logging/MdcHelper.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/logging/MdcHelper.java
@@ -8,13 +8,12 @@ public class MdcHelper {
     private MdcHelper() {}
 
     public static void addContextToMdc(AttributeQuery attributeQuery) {
-        addContextToMdc("AttributeQuery", attributeQuery.getID(), attributeQuery.getIssuer().getValue());
-    }
+        String messageId = attributeQuery.getID();
+        String entityID = attributeQuery.getIssuer().getValue();
 
-    private static void addContextToMdc(String messageType, String messageId, String entityID) {
         MDC.put("messageId", messageId);
         MDC.put("entityId", entityID);
-        MDC.put("logPrefix", "[" + messageType + " " + messageId + " from " + entityID + "] ");
+        MDC.put("logPrefix", "[AttributeQuery " + messageId + " from " + entityID + "] ");
+        
     }
-
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/rest/soap/SoapMessageManager.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/rest/soap/SoapMessageManager.java
@@ -15,7 +15,6 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import static com.google.common.base.Throwables.propagate;
 import static java.text.MessageFormat.format;
 import static uk.gov.ida.shared.utils.xml.XmlUtils.newDocumentBuilder;
 
@@ -29,7 +28,7 @@ public class SoapMessageManager {
             documentBuilder = newDocumentBuilder();
         } catch (ParserConfigurationException e) {
             LOG.error("*** ALERT: Failed to create a document builder when trying to construct the the soap message. ***", e);
-            throw propagate(e);
+            throw new RuntimeException(e);
         }
         Document document = documentBuilder.newDocument();
         document.adoptNode(element);
@@ -67,7 +66,7 @@ public class SoapMessageManager {
 
             return element;
         } catch (XPathExpressionException e) {
-            throw propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
@@ -14,7 +14,7 @@ import javax.xml.namespace.QName;
 import java.util.List;
 import java.util.Optional;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 public abstract class AssertionService {
     protected final InstantValidator instantValidator;
@@ -43,7 +43,7 @@ public abstract class AssertionService {
                                         String expectedInResponseTo,
                                         String hubEntityId,
                                         QName role) {
-        hubSignatureValidator.validate(asList(assertion), role);
+        hubSignatureValidator.validate(singletonList(assertion), role);
         instantValidator.validate(assertion.getIssueInstant(), "Hub Assertion IssueInstant");
         subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
         if (assertion.getConditions() != null) {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/AttributeQueryService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/AttributeQueryService.java
@@ -9,9 +9,7 @@ import uk.gov.ida.matchingserviceadapter.validators.AttributeQuerySignatureValid
 import uk.gov.ida.matchingserviceadapter.validators.InstantValidator;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class AttributeQueryService {
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
@@ -20,7 +20,7 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 public class EidasAssertionService extends AssertionService {
 
@@ -87,7 +87,7 @@ public class EidasAssertionService extends AssertionService {
                 .map(SamlMessageSignatureValidator::new)
                 .map(SamlAssertionsSignatureValidator::new)
                 .orElseThrow(() -> new SamlResponseValidationException("Unable to find metadata resolver for entity Id " + assertion.getIssuer().getValue()))
-                .validate(asList(assertion), IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+                .validate(singletonList(assertion), IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
         instantValidator.validate(assertion.getIssueInstant(), "Country Assertion IssueInstant");
         subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
         conditionsValidator.validate(assertion.getConditions(), hubConnectorEntityId);


### PR DESCRIPTION
Removed reference to depricated Trowables.propogate(e).
Removed reference to depricated ISO8601DateFormat().
Cleaned up unused imports.
Simplified unnecessary private method call.
Changed to use SingletonList where appropriate.