### PR TITLE
VCU-93: MSA Release Notes for Java 9 and 10 changes.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ MSA Release Notes
 ### Next
 
 * Put back post-matching logging status which had been removed in [release 3.0.0](RELEASE_NOTES.md#300)
-* Included support for compilation on Java 9 and 10, and creation of multi-release jars.
+* Included support for compilation on Java 9 and 10, and creation of multi-release JAR files.
 
 ### 3.0.1
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/3.0.0...3.0.1)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@ MSA Release Notes
 ### Next
 
 * Put back post-matching logging status which had been removed in [release 3.0.0](RELEASE_NOTES.md#300)
+* Included support for compilation on Java 9 and 10, and creation of multi-release jars.
 
 ### 3.0.1
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/3.0.0...3.0.1)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,8 +3,8 @@ MSA Release Notes
 
 ### Next
 
-* Put back post-matching logging status which had been removed in [release 3.0.0](RELEASE_NOTES.md#300)
-* Included support for compilation on Java 9 and 10, and creation of multi-release JAR files.
+* Re-introduced post-matching logging status which had been removed in [release 3.0.0](RELEASE_NOTES.md#300)
+* Included support for compilation on Java 9 and 10. Compilation on Java 9 or 10 will produce a multi-release JAR that will run on Java 8, 9, and 10. This release was compiled on Java 8 and does not contain a multi-release JAR.
 
 ### 3.0.1
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/3.0.0...3.0.1)


### PR DESCRIPTION
SUPPORT FOR COMPILATION ON JAVA 9 AND 10

- The MSA can now be compiled and run on Java 9 and 10.
- This release has still been compiled on Java 8.
- Gradle Build Script changes were made to support the Java versions above.

MULTI-RELEASE JARS

- Compiling on Java 9 or 10 will produce a multi-release jar.
- A multi-release jar is produced by default when compiling with Java 9 or 10.
- In this case all existing code is compiled with the '--release 8' flag.
- This means any jar compiled with Java 9 or 10 can be executed under Java 8, giving users the flexibility to stay on an earlier Java version if required.
