### PR TITLE
VCU-87: Java 10 builds mandatory in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ jdk:
   - openjdk11
 matrix:
   allow_failures:
-  - jdk: oraclejdk9
-  - jdk: oraclejdk10
-  - jdk: openjdk9
-  - jdk: openjdk10
   - jdk: openjdk11
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@ MSA Release Notes
 ### Next
 
 * Put back post-matching logging status which had been removed in [release 3.0.0](RELEASE_NOTES.md#300)
+* Included support for compilation on Java 9 and 10, and creation of multi-release jars.
 
 ### 3.0.1
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/3.0.0...3.0.1)


### PR DESCRIPTION
Build-breaker on JDK:oraclejdk10 and JDK:openjdk10.
Enforce Java 10 compatibility on all MSA changes.