### PR TITLE
Eid 774

### DIFF
--- a/src/integration-test/java/uk/gov/ida/integrationtest/VerifyMatchingIntegrationTest.java
+++ b/src/integration-test/java/uk/gov/ida/integrationtest/VerifyMatchingIntegrationTest.java
@@ -322,37 +322,6 @@ public class VerifyMatchingIntegrationTest {
         assertThat(response.getStatus().getStatusMessage().getMessage()).contains("IDP matching dataset and authn statement assertions do not contain matching issuers");
     }
 
-    @Test
-    public void shouldReturnErrorResponseWhenAnAttributeQueryRequestContainsIdpMatchingDatasetAssertionWithInResponseToNotMatchingRequestId() {
-        AttributeQuery attributeQuery = AttributeQueryBuilder.anAttributeQuery()
-                .withId(REQUEST_ID)
-                .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
-                .withSubject(aSubjectWithAssertions(asList(
-                        anAuthnStatementAssertion("default-request-id"),
-                        aMatchingDatasetAssertion(Collections.emptyList(), false, "wrong-request-id")), REQUEST_ID, HUB_ENTITY_ID))
-                .build();
-
-        Response response = makeAttributeQueryRequest(MATCHING_SERVICE_URI, attributeQuery, signatureAlgorithmForHub, digestAlgorithmForHub, HUB_ENTITY_ID);
-
-        assertThat(response.getStatus().getStatusCode().getValue()).isEqualTo(REQUESTER);
-        assertThat(response.getStatus().getStatusMessage().getMessage()).contains("'InResponseTo' must match requestId. Expected default-request-id but was wrong-request-id");
-    }
-
-    @Test
-    public void shouldReturnErrorResponseWhenAnAttributeQueryRequestContainsIdpAuthnAssertionWithInResponseToNotMatchingRequestId() {
-        AttributeQuery attributeQuery = AttributeQueryBuilder.anAttributeQuery()
-                .withId(REQUEST_ID)
-                .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
-                .withSubject(aSubjectWithAssertions(asList(
-                        anAuthnStatementAssertion("wrong-request-id"),
-                        aMatchingDatasetAssertion(Collections.emptyList(), false, REQUEST_ID)), REQUEST_ID, HUB_ENTITY_ID))
-                .build();
-
-        Response response = makeAttributeQueryRequest(MATCHING_SERVICE_URI, attributeQuery, signatureAlgorithmForHub, digestAlgorithmForHub, HUB_ENTITY_ID);
-
-        assertThat(response.getStatus().getStatusCode().getValue()).isEqualTo(REQUESTER);
-        assertThat(response.getStatus().getStatusMessage().getMessage()).contains("'InResponseTo' must match requestId. Expected default-request-id but was wrong-request-id");
-    }
 
     @Test
     public void shouldReturnAHealthyResponseToAValidHealthcheckGivenValidMetadata() {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.matchingserviceadapter.services;
 
+import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import uk.gov.ida.matchingserviceadapter.domain.AssertionData;
@@ -44,14 +45,25 @@ public abstract class AssertionService {
                                         String expectedInResponseTo,
                                         String hubEntityId,
                                         QName role) {
-        if (assertion.getIssueInstant() == null){
-            throw new SamlResponseValidationException("Assertion IssueInstant cannot be null.");
+
+        if (assertion.getIssueInstant() == null) {
+            throw new SamlResponseValidationException("Assertion IssueInstant is missing.");
         }
-        if (assertion.getID() == null || assertion.getID().length() == 0){
-            throw new SamlResponseValidationException("Assertion Id cannot be null or blank.");
+
+        if (assertion.getID() == null || assertion.getID().length() == 0) {
+            throw new SamlResponseValidationException("Assertion Id is missing or blank.");
         }
-        if (assertion.getIssuer() == null || assertion.getIssuer().getValue() == null || assertion.getIssuer().getValue().length() == 0){
-            throw new SamlResponseValidationException("Assertion Issuer cannot be null or blank.");
+
+        if (assertion.getIssuer() == null || assertion.getIssuer().getValue() == null || assertion.getIssuer().getValue().length() == 0) {
+            throw new SamlResponseValidationException("Assertion with id " + assertion.getID() + " has missing or blank Issuer.");
+        }
+
+        if (assertion.getVersion() == null) {
+            throw new SamlResponseValidationException("Assertion with id " + assertion.getID() + " has Version missing Version.");
+        }
+
+        if (!assertion.getVersion().equals(SAMLVersion.VERSION_20)) {
+            throw new SamlResponseValidationException("Assertion with id " + assertion.getID() + " declared an illegal Version attribute value.");
         }
 
         hubSignatureValidator.validate(singletonList(assertion), role);

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
@@ -44,9 +44,8 @@ public abstract class AssertionService {
                                         String hubEntityId,
                                         QName role) {
         hubSignatureValidator.validate(singletonList(assertion), role);
-        instantValidator.validate(assertion.getIssueInstant(), "Hub Assertion IssueInstant");
         subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
-        
+
     }
 
     protected void validateCycle3Assertion(Assertion assertion, String requestId, String hubEntityId) {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
@@ -50,7 +50,7 @@ public abstract class AssertionService {
         if (assertion.getID() == null || assertion.getID().length() == 0){
             throw new SamlResponseValidationException("Assertion Id cannot be null or blank.");
         }
-        if(assertion.getIssuer() == null || assertion.getIssuer() == null || assertion.getIssuer().getValue().length() == 0){
+        if (assertion.getIssuer() == null || assertion.getIssuer().getValue() == null || assertion.getIssuer().getValue().length() == 0){
             throw new SamlResponseValidationException("Assertion Issuer cannot be null or blank.");
         }
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
@@ -3,6 +3,7 @@ package uk.gov.ida.matchingserviceadapter.services;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import uk.gov.ida.matchingserviceadapter.domain.AssertionData;
+import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
 import uk.gov.ida.matchingserviceadapter.validators.ConditionsValidator;
 import uk.gov.ida.matchingserviceadapter.validators.InstantValidator;
 import uk.gov.ida.matchingserviceadapter.validators.SubjectValidator;
@@ -43,6 +44,16 @@ public abstract class AssertionService {
                                         String expectedInResponseTo,
                                         String hubEntityId,
                                         QName role) {
+        if (assertion.getIssueInstant() == null){
+            throw new SamlResponseValidationException("Assertion IssueInstant cannot be null.");
+        }
+        if (assertion.getID() == null || assertion.getID().length() == 0){
+            throw new SamlResponseValidationException("Assertion Id cannot be null or blank.");
+        }
+        if(assertion.getIssuer() == null || assertion.getIssuer() == null || assertion.getIssuer().getValue().length() == 0){
+            throw new SamlResponseValidationException("Assertion Issuer cannot be null or blank.");
+        }
+
         hubSignatureValidator.validate(singletonList(assertion), role);
         subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
@@ -46,9 +46,7 @@ public abstract class AssertionService {
         hubSignatureValidator.validate(singletonList(assertion), role);
         instantValidator.validate(assertion.getIssueInstant(), "Hub Assertion IssueInstant");
         subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
-        if (assertion.getConditions() != null) {
-            conditionsValidator.validate(assertion.getConditions(), hubEntityId);
-        }
+        
     }
 
     protected void validateCycle3Assertion(Assertion assertion, String requestId, String hubEntityId) {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
@@ -51,13 +51,13 @@ public class EidasAssertionService extends AssertionService {
 
     @Override
     void validate(String expectedInResponseTo, List<Assertion> assertions) {
-        for (Assertion assertion : assertions){
-            if(isCountryAssertion(assertion)){
+        for (Assertion assertion : assertions) {
+            if (isCountryAssertion(assertion)) {
                 validateCountryAssertion(assertion, expectedInResponseTo);
-            }else if(isHubAssertion(assertion)){
+            } else if (isHubAssertion(assertion)) {
                 validateCycle3Assertion(assertion, expectedInResponseTo, hubEntityId);
-            }else{
-                throw new SamlResponseValidationException("Unknown Issuer for eIDAS Assertion: "+assertion.getIssuer().getValue());
+            } else {
+                throw new SamlResponseValidationException("Unknown Issuer for eIDAS Assertion: " + assertion.getIssuer().getValue());
             }
         }
     }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionService.java
@@ -42,7 +42,6 @@ public class VerifyAssertionService extends AssertionService {
         this.matchingDatasetUnmarshaller = matchingDatasetUnmarshaller;
     }
 
-
     @Override
     public void validate(String requestId, List<Assertion> assertions) {
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/SubjectValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/SubjectValidator.java
@@ -22,21 +22,17 @@ public class SubjectValidator {
             throw new SamlResponseValidationException("Subject is missing from the assertion.");
         }
 
-        if (subject.getSubjectConfirmations().size() != 1) {
-            throw new SamlResponseValidationException("Exactly one subject confirmation is expected.");
+        if (subject.getSubjectConfirmations().size() == 0) {
+            throw new SamlResponseValidationException("A subject confirmation is expected.");
         }
 
         SubjectConfirmation subjectConfirmation = subject.getSubjectConfirmations().get(0);
-        if (!METHOD_BEARER.equals(subjectConfirmation.getMethod())) {
-            throw new SamlResponseValidationException("Subject confirmation method must be 'bearer'.");
-        }
+
 
         SubjectConfirmationData subjectConfirmationData = subjectConfirmation.getSubjectConfirmationData();
         if (subjectConfirmationData == null) {
             throw new SamlResponseValidationException("Subject confirmation data is missing from the assertion.");
         }
-
-        timeRestrictionValidator.validateNotBefore(subjectConfirmationData.getNotBefore());
 
         DateTime notOnOrAfter = subjectConfirmationData.getNotOnOrAfter();
         if (notOnOrAfter == null) {
@@ -48,10 +44,6 @@ public class SubjectValidator {
         String actualInResponseTo = subjectConfirmationData.getInResponseTo();
         if (actualInResponseTo == null) {
             throw new SamlResponseValidationException("Subject confirmation data must contain 'InResponseTo'.");
-        }
-
-        if (!expectedInResponseTo.equals(actualInResponseTo)) {
-            throw new SamlResponseValidationException(String.format("'InResponseTo' must match requestId. Expected %s but was %s", expectedInResponseTo, actualInResponseTo));
         }
 
         if (subject.getNameID() == null) {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/SubjectValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/SubjectValidator.java
@@ -2,12 +2,11 @@ package uk.gov.ida.matchingserviceadapter.validators;
 
 import com.google.inject.Inject;
 import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.NameIDType;
 import org.opensaml.saml.saml2.core.Subject;
 import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import org.opensaml.saml.saml2.core.SubjectConfirmationData;
 import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
-
-import static org.opensaml.saml.saml2.core.SubjectConfirmation.METHOD_BEARER;
 
 public class SubjectValidator {
     TimeRestrictionValidator timeRestrictionValidator;
@@ -48,6 +47,14 @@ public class SubjectValidator {
 
         if (subject.getNameID() == null) {
             throw new SamlResponseValidationException("NameID is missing from the subject of the assertion.");
+        }
+
+        if (subject.getNameID().getFormat() == null || subject.getNameID().getFormat().length() == 0) {
+            throw new SamlResponseValidationException("NameID format is missing or empty in the subject of the assertion.");
+        }
+
+        if (!subject.getNameID().getFormat().equals(NameIDType.PERSISTENT)) {
+            throw new SamlResponseValidationException("NameID format is invalid in the subject of the assertion.");
         }
     }
 }

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionServiceTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
+import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.Subject;
@@ -115,8 +116,8 @@ public class VerifyAssertionServiceTest {
         assertion.setIssueInstant(null);
 
         exception.expect(SamlResponseValidationException.class);
-        exception.expectMessage("Assertion IssueInstant cannot be null.");
-        verifyAssertionService.validateHubAssertion(assertion, "not-used", "", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        exception.expectMessage("Assertion IssueInstant is missing.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
@@ -125,8 +126,8 @@ public class VerifyAssertionServiceTest {
         assertion.setID(null);
 
         exception.expect(SamlResponseValidationException.class);
-        exception.expectMessage("Assertion Id cannot be null or blank.");
-        verifyAssertionService.validateHubAssertion(assertion, "not-used", "", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        exception.expectMessage("Assertion Id is missing or blank.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
@@ -135,8 +136,8 @@ public class VerifyAssertionServiceTest {
         assertion.setID("");
 
         exception.expect(SamlResponseValidationException.class);
-        exception.expectMessage("Assertion Id cannot be null or blank.");
-        verifyAssertionService.validateHubAssertion(assertion, "not-used", "", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        exception.expectMessage("Assertion Id is missing or blank.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
@@ -145,8 +146,8 @@ public class VerifyAssertionServiceTest {
         assertion.setIssuer(null);
 
         exception.expect(SamlResponseValidationException.class);
-        exception.expectMessage("Assertion Issuer cannot be null or blank.");
-        verifyAssertionService.validateHubAssertion(assertion, "not-used", "", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        exception.expectMessage("Assertion with id mds-assertion has missing or blank Issuer.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
@@ -155,8 +156,8 @@ public class VerifyAssertionServiceTest {
         assertion.setIssuer(anIssuer().withIssuerId(null).build());
 
         exception.expect(SamlResponseValidationException.class);
-        exception.expectMessage("Assertion Issuer cannot be null or blank.");
-        verifyAssertionService.validateHubAssertion(assertion, "not-used", "", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        exception.expectMessage("Assertion with id mds-assertion has missing or blank Issuer.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test
@@ -165,8 +166,29 @@ public class VerifyAssertionServiceTest {
         assertion.setIssuer(anIssuer().withIssuerId("").build());
 
         exception.expect(SamlResponseValidationException.class);
-        exception.expectMessage("Assertion Issuer cannot be null or blank.");
-        verifyAssertionService.validateHubAssertion(assertion, "not-used", "", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        exception.expectMessage("Assertion with id mds-assertion has missing or blank Issuer.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfMissingAssertionVersionWhenValidatingHubAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setVersion(null);
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion with id mds-assertion has Version missing Version.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+
+    @Test
+    public void shouldThrowExceptionIfAssertionVersionInvalidWhenValidatingHubAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setVersion(SAMLVersion.VERSION_10);
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion with id mds-assertion declared an illegal Version attribute value.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     @Test

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionServiceTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionServiceTest.java
@@ -109,9 +109,7 @@ public class VerifyAssertionServiceTest {
                 anAuthnStatementAssertion(IdaAuthnContext.LEVEL_2_AUTHN_CTX, "requestId").buildUnencrypted());
 
         verifyAssertionService.validate("requestId", assertions);
-        verify(instantValidator, times(2)).validate(any(), any());
         verify(subjectValidator, times(2)).validate(any(), any());
-        verify(conditionsValidator, times(2)).validate(any(), any());
         verify(hubSignatureValidator, times(2)).validate(any(), any());
     }
 

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionServiceTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionServiceTest.java
@@ -176,7 +176,7 @@ public class VerifyAssertionServiceTest {
         assertion.setVersion(null);
 
         exception.expect(SamlResponseValidationException.class);
-        exception.expectMessage("Assertion with id mds-assertion has Version missing Version.");
+        exception.expectMessage("Assertion with id mds-assertion has missing Version.");
         verifyAssertionService.validateHubAssertion(assertion, "not-used", "not-used", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionServiceTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionServiceTest.java
@@ -108,15 +108,64 @@ public class VerifyAssertionServiceTest {
     public void tearDown() {
         DateTimeFreezer.unfreezeTime();
     }
-
-
+    
     @Test
-    public void shouldThrowExceptionIfIssuerInstanceMissing() {
+    public void shouldThrowExceptionIfIssueInstantMissingWhenValidatingHubAssertion() {
         Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
         assertion.setIssueInstant(null);
 
         exception.expect(SamlResponseValidationException.class);
         exception.expectMessage("Assertion IssueInstant cannot be null.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfAssertionIdIsMissingWhenValidatingHubAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setID(null);
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion Id cannot be null or blank.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfAssertionIdIsBlankWhenValidatingHubAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setID("");
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion Id cannot be null or blank.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfIssuerMissingWhenValidatingHubAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setIssuer(null);
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion Issuer cannot be null or blank.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfIssuerValueMissingWhenValidatingHubAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setIssuer(anIssuer().withIssuerId(null).build());
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion Issuer cannot be null or blank.");
+        verifyAssertionService.validateHubAssertion(assertion, "not-used", "", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfIssuerValueIsBlankWhenValidatingHubAssertion() {
+        Assertion assertion = aMatchingDatasetAssertionWithSignature(emptyList(), anIdpSignature(), "requestId").buildUnencrypted();
+        assertion.setIssuer(anIssuer().withIssuerId("").build());
+
+        exception.expect(SamlResponseValidationException.class);
+        exception.expectMessage("Assertion Issuer cannot be null or blank.");
         verifyAssertionService.validateHubAssertion(assertion, "not-used", "", IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validator/SubjectValidatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validator/SubjectValidatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.matchingserviceadapter.validator;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,6 +14,7 @@ import uk.gov.ida.matchingserviceadapter.validators.SubjectValidator;
 import uk.gov.ida.matchingserviceadapter.validators.TimeRestrictionValidator;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 
+import static uk.gov.ida.saml.core.test.builders.NameIdBuilder.aNameId;
 import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
 import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
 import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder.aSubjectConfirmationData;
@@ -37,16 +37,15 @@ public class SubjectValidatorTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenSubjectIsMissing() throws Exception {
+    public void shouldThrowExceptionWhenSubjectIsMissing() {
         expectedException.expect(SamlResponseValidationException.class);
         expectedException.expectMessage("Subject is missing from the assertion.");
 
         subjectValidator.validate(null, IN_RESPONSE_TO);
     }
 
-
     @Test
-    public void shouldThrowExceptionWhenSubjectConfirmationDataMissing() throws Exception {
+    public void shouldThrowExceptionWhenSubjectConfirmationDataMissing() {
         expectedException.expect(SamlResponseValidationException.class);
         expectedException.expectMessage("Subject confirmation data is missing from the assertion.");
 
@@ -58,7 +57,7 @@ public class SubjectValidatorTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenSubjectConfirmationDataNotOnOrAfterIsMissing() throws Exception {
+    public void shouldThrowExceptionWhenSubjectConfirmationDataNotOnOrAfterIsMissing() {
         expectedException.expect(SamlResponseValidationException.class);
         expectedException.expectMessage("Subject confirmation data must contain 'NotOnOrAfter'.");
 
@@ -72,7 +71,7 @@ public class SubjectValidatorTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenSubjectConfirmationDataHasNoInResponseTo() throws Exception {
+    public void shouldThrowExceptionWhenSubjectConfirmationDataHasNoInResponseTo() {
         expectedException.expect(SamlResponseValidationException.class);
         expectedException.expectMessage("Subject confirmation data must contain 'InResponseTo'.");
 
@@ -87,10 +86,8 @@ public class SubjectValidatorTest {
         subjectValidator.validate(subject, IN_RESPONSE_TO);
     }
 
-
-
     @Test
-    public void shouldThrowExceptionWhenNameIdIsMissing() throws Exception {
+    public void shouldThrowExceptionWhenNameIdIsMissing() {
         expectedException.expect(SamlResponseValidationException.class);
         expectedException.expectMessage("NameID is missing from the subject of the assertion.");
 
@@ -106,5 +103,54 @@ public class SubjectValidatorTest {
         subjectValidator.validate(subject, IN_RESPONSE_TO);
     }
 
+    @Test
+    public void shouldThrowExceptionWhenNameIdFormatIsMissing() {
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage("NameID format is missing or empty in the subject of the assertion.");
 
+        SubjectConfirmation subjectConfirmation = aSubjectConfirmation().withSubjectConfirmationData(
+                aSubjectConfirmationData()
+                        .withInResponseTo(IN_RESPONSE_TO)
+                        .build()).build();
+        Subject subject = aSubject()
+                .withSubjectConfirmation(subjectConfirmation)
+                .withNameId(aNameId().withFormat(null).build())
+                .build();
+
+        subjectValidator.validate(subject, IN_RESPONSE_TO);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenNameIdFormatIsEmpty() {
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage("NameID format is missing or empty in the subject of the assertion.");
+
+        SubjectConfirmation subjectConfirmation = aSubjectConfirmation().withSubjectConfirmationData(
+                aSubjectConfirmationData()
+                        .withInResponseTo(IN_RESPONSE_TO)
+                        .build()).build();
+        Subject subject = aSubject()
+                .withSubjectConfirmation(subjectConfirmation)
+                .withNameId(aNameId().withFormat("").build())
+                .build();
+
+        subjectValidator.validate(subject, IN_RESPONSE_TO);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenNameIdFormatIsNotValid() {
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage("NameID format is invalid in the subject of the assertion.");
+
+        SubjectConfirmation subjectConfirmation = aSubjectConfirmation().withSubjectConfirmationData(
+                aSubjectConfirmationData()
+                        .withInResponseTo(IN_RESPONSE_TO)
+                        .build()).build();
+        Subject subject = aSubject()
+                .withSubjectConfirmation(subjectConfirmation)
+                .withNameId(aNameId().withFormat("invalid-nameid-format").build())
+                .build();
+
+        subjectValidator.validate(subject, IN_RESPONSE_TO);
+    }
 }

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validator/SubjectValidatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validator/SubjectValidatorTest.java
@@ -44,29 +44,6 @@ public class SubjectValidatorTest {
         subjectValidator.validate(null, IN_RESPONSE_TO);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenMultipleSubjectConfirmation() throws Exception {
-        expectedException.expect(SamlResponseValidationException.class);
-        expectedException.expectMessage("Exactly one subject confirmation is expected.");
-
-        Subject subject = aSubject().build();
-        SubjectConfirmation subjectConfirmation = aSubjectConfirmation().build();
-        subject.getSubjectConfirmations().addAll(ImmutableList.of(subjectConfirmation, subjectConfirmation));
-
-        subjectValidator.validate(subject, IN_RESPONSE_TO);
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenSubjectConfirmationMethodIsNotBearer() throws Exception {
-        expectedException.expect(SamlResponseValidationException.class);
-        expectedException.expectMessage("Subject confirmation method must be 'bearer'.");
-
-        Subject subject = aSubject()
-                .withSubjectConfirmation(aSubjectConfirmation().withMethod("anything-but-not-bearer").build())
-                .build();
-
-        subjectValidator.validate(subject, IN_RESPONSE_TO);
-    }
 
     @Test
     public void shouldThrowExceptionWhenSubjectConfirmationDataMissing() throws Exception {
@@ -110,22 +87,7 @@ public class SubjectValidatorTest {
         subjectValidator.validate(subject, IN_RESPONSE_TO);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenInResponseToRequestIdDoesNotMatchTheRequestId() throws Exception {
-        String expectedInResponseTo = "some-non-matching-request-id";
-        expectedException.expect(SamlResponseValidationException.class);
-        expectedException.expectMessage("'InResponseTo' must match requestId. Expected " + expectedInResponseTo + " but was " + IN_RESPONSE_TO);
 
-        SubjectConfirmation subjectConfirmation = aSubjectConfirmation().withSubjectConfirmationData(
-                aSubjectConfirmationData()
-                        .withInResponseTo(IN_RESPONSE_TO)
-                        .build()).build();
-        Subject subject = aSubject()
-                .withSubjectConfirmation(subjectConfirmation)
-                .build();
-
-        subjectValidator.validate(subject, expectedInResponseTo);
-    }
 
     @Test
     public void shouldThrowExceptionWhenNameIdIsMissing() throws Exception {


### PR DESCRIPTION
# The issue

MSA version 3.0.x has a load of strict validations newly added that is currently causing issues. Assertions from certain IdP(s) are currently failing these validation and the MSA.

One of the relying parties is using the new MSA in production and they currently have users not being able to complete journeys when their responses are rejected by the MSA.

# The fix - remove the newly added problematic validations

Below are the validations that are newly added:
* `<Conditions>`
    * MUST NOT contain an `<ProxyRestrictions>` element 
    * MUST NOT contain an `<OneTimeUse>` element 
    * `NotOnOrAfter` attribute value MUST be before current time 
    * `NotBefore` attribute value MUST be after current time 
    * MUST contain exactly 1 `<AudienceRestriction>` element 
    * `<AudienceRestriction>` MUST contain exactly 1 `<Audience>` element 
    * `<Audience>` MUST contain the the entity id for hub 
* `<SubjectConfirmationData>`
    * `NotBefore` attribute MUST be after current time 
    * `InResponseTo` attribute value of `<SubjectConfirmationData>` MUST match the Id attribute value of the `<AttributeQuery>` element 
* `<Assertion>`
    * `<IssueInstant>` element MUST NOT be older than 5 minutes. 
This is what we need to do:
* Remove validator of the whole `<Conditions>` element 
* Remove the followings under  `<SubjectConfirmationData>` :
    * `NotBefore` attribute MUST be after current time 
    * `InResponseTo` attribute value MUST match the Id attribute value of the `<AttributeQuery>` element 
* Remove the validation on `<IssueInstant>` element under `<Assertion>` MUST NOT be older than 5 minutes 


