### PR TITLE
EID-835 - Give the MSA support for the RSASSA-PSS and ECDSA algorithms

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,8 @@ MSA Release Notes
 
 ### Next
 
+* Upgrade SAML libs version so that the MSA can support the ECDSA and RSASSA-PSS signing algorithms to fulfil the eIDAS cryptographic requirements
+as laid out in the "eIDAS - Cryptographic requirements for the Interoperability Framework". 
 * Upgrade to Dropwizard 1.3.5 plus updated various other libs, specifically: ida_utils, ida_test_utils, hub_saml, saml_libs_version.
 
 ### 3.0.3

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ def dependencyVersions = [
         hub_saml: "$opensaml-15606",
         dev_pki: '1.1.0-34',
         trust_anchor: '1.0-34',
-        saml_libs_version: "$opensaml-153"
+        saml_libs_version: "$opensaml-157"
 ]
 
 repositories {

--- a/src/integration-test/java/uk/gov/ida/integrationtest/EidasMatchingIntegrationTest.java
+++ b/src/integration-test/java/uk/gov/ida/integrationtest/EidasMatchingIntegrationTest.java
@@ -22,7 +22,6 @@ import org.opensaml.saml.saml2.core.AttributeQuery;
 import org.opensaml.xmlsec.algorithm.DigestAlgorithm;
 import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
 import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA256;
-import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA1;
 import org.opensaml.xmlsec.signature.Signature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +33,7 @@ import uk.gov.ida.matchingserviceadapter.rest.Urls;
 import uk.gov.ida.matchingserviceadapter.rest.soap.SoapMessageManager;
 import uk.gov.ida.saml.core.test.TestCredentialFactory;
 import uk.gov.ida.saml.core.test.builders.AttributeQueryBuilder;
+import uk.gov.ida.saml.security.signature.SignatureRSASSAPSS;
 import uk.gov.ida.saml.serializers.XmlObjectToElementTransformer;
 import uk.gov.ida.shared.utils.xml.XmlUtils;
 
@@ -74,7 +74,7 @@ public class EidasMatchingIntegrationTest {
 
     private static final String REQUEST_ID = "a-request-id";
     private static final String MATCHING_REQUEST_PATH = "/matching-request";
-    private static final SignatureAlgorithm SIGNATURE_ALGORITHM = new SignatureRSASHA1();
+    private static final SignatureAlgorithm SIGNATURE_ALGORITHM = new SignatureRSASSAPSS();
     private static final DigestAlgorithm DIGEST_ALGORITHM = new DigestSHA256();
 
     private static Client client;


### PR DESCRIPTION
- A change has been made to saml libs to give support to the above signing algorithms. 
- This is to fulfil eidas crypto requriements as laid out in the spec
- Use RSASSA-PSS signing algorithm for eidas integration tests

Co-authored-by: Simon Worthington <simon.worthington@digital.cabinet-office.gov.uk>