### PR TITLE
EID-842: Support transient NameID format for middleware

### DIFF
--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/SubjectValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/SubjectValidator.java
@@ -8,6 +8,8 @@ import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import org.opensaml.saml.saml2.core.SubjectConfirmationData;
 import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
 
+import java.util.stream.Stream;
+
 public class SubjectValidator {
     TimeRestrictionValidator timeRestrictionValidator;
 
@@ -53,7 +55,11 @@ public class SubjectValidator {
             throw new SamlResponseValidationException("NameID format is missing or empty in the subject of the assertion.");
         }
 
-        if (!subject.getNameID().getFormat().equals(NameIDType.PERSISTENT)) {
+        boolean correctNameIdType = Stream
+                .of(NameIDType.PERSISTENT, NameIDType.TRANSIENT)
+                .anyMatch(type -> type.equals(subject.getNameID().getFormat()));
+
+        if (!correctNameIdType) {
             throw new SamlResponseValidationException("NameID format is invalid in the subject of the assertion.");
         }
     }


### PR DESCRIPTION
The German eIDAS Middleware returns NameIDs with the format set to
*transient*. Normally, Verify IDPs return *persistent*. We should allow
the validator to accept both types of NameID since it doesn't really
affect the journey.