### PR TITLE
96: Convert PEM certificates to base64-encoded DER properly

### DIFF
--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -351,7 +351,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
                 publicSigningCertificates);
     }
 
-    private Certificate cert(String keyName, String cert, Certificate.KeyUse keyUse) {
+    public Certificate cert(String keyName, String cert, Certificate.KeyUse keyUse) {
         String certBody = cert
                 .replace("-----BEGIN CERTIFICATE-----", "")
                 .replace("-----END CERTIFICATE-----", "")

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -6,6 +6,7 @@ import com.google.inject.Provides;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.setup.Environment;
+import org.apache.commons.codec.binary.Base64;
 import org.joda.time.Duration;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver;
@@ -36,6 +37,7 @@ import uk.gov.ida.matchingserviceadapter.domain.OutboundResponseFromMatchingServ
 import uk.gov.ida.matchingserviceadapter.domain.OutboundResponseFromUnknownUserCreationService;
 import uk.gov.ida.matchingserviceadapter.domain.UserAccountCreationAttributeExtractor;
 import uk.gov.ida.matchingserviceadapter.exceptions.ExceptionResponseFactory;
+import uk.gov.ida.matchingserviceadapter.exceptions.InvalidCertificateException;
 import uk.gov.ida.matchingserviceadapter.mappers.MatchingDatasetToMatchingDatasetDtoMapper;
 import uk.gov.ida.matchingserviceadapter.mappers.MatchingServiceRequestDtoMapper;
 import uk.gov.ida.matchingserviceadapter.mappers.MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper;
@@ -92,6 +94,8 @@ import uk.gov.ida.truststore.KeyStoreLoader;
 import javax.annotation.Nullable;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import javax.security.cert.CertificateException;
+import javax.security.cert.X509Certificate;
 import javax.ws.rs.client.Client;
 import java.io.PrintWriter;
 import java.security.KeyPair;
@@ -352,11 +356,13 @@ class MatchingServiceAdapterModule extends AbstractModule {
     }
 
     public Certificate cert(String keyName, String cert, Certificate.KeyUse keyUse) {
-        String certBody = cert
-                .replace("-----BEGIN CERTIFICATE-----", "")
-                .replace("-----END CERTIFICATE-----", "")
-                .replace(" ", "");
-        return new Certificate(keyName, certBody, keyUse);
+        try {
+            X509Certificate x509cert = X509Certificate.getInstance(cert.getBytes());
+            String certBody = Base64.encodeBase64String(x509cert.getEncoded());
+            return new Certificate(keyName, certBody, keyUse);
+        } catch (CertificateException e) {
+            throw new InvalidCertificateException(e);
+        }
     }
 
     @Provides

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/InvalidCertificateException.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/InvalidCertificateException.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.matchingserviceadapter.exceptions;
+
+public class InvalidCertificateException extends RuntimeException {
+    public InvalidCertificateException(Throwable t) {
+        super(t);
+    }
+}

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModuleTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModuleTest.java
@@ -1,0 +1,27 @@
+package uk.gov.ida.matchingserviceadapter;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import uk.gov.ida.common.shared.security.Certificate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MatchingServiceAdapterModuleTest {
+
+    private static final String CERT = "-----BEGIN CERTIFICATE-----\nMIIBGzCBxgIJAL0noY5tc8OPMA0GCSqGSIb3DQEBCwUAMBUxEzARBgNVBAMMCnNl\nbGZzaWduZWQwHhcNMTgwODIzMDY1MzM2WhcNMTkwODIzMDY1MzM2WjAVMRMwEQYD\nVQQDDApzZWxmc2lnbmVkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAMS856cUwkeE\nrqtE+IyfzSFHECkKsOw35xQTNo3u32IjbwzykzOC2x+Pvyh47U3DXM52wPzi3uiL\n+GB4WOtEL0cCAwEAATANBgkqhkiG9w0BAQsFAANBAIIrGyaQCLIqCutaICJbdbIN\nmUzVkrY1iFLRVrfSZ37Ush1sxqpr/YHRf+apHMRXHlITuBrU8HIZbYEiaJUP718=\n-----END CERTIFICATE-----";
+
+    @Test
+    public void testCertLoading() {
+        MatchingServiceAdapterModule matchingServiceAdapterModule = new MatchingServiceAdapterModule();
+        final Certificate certificate = matchingServiceAdapterModule.cert("test cert", CERT, uk.gov.ida.common.shared.security.Certificate.KeyUse.Signing);
+        assertThat(certificate.getCertificate()).isEqualTo("\nMIIBGzCBxgIJAL0noY5tc8OPMA0GCSqGSIb3DQEBCwUAMBUxEzARBgNVBAMMCnNl\nbGZzaWduZWQwHhcNMTgwODIzMDY1MzM2WhcNMTkwODIzMDY1MzM2WjAVMRMwEQYD\nVQQDDApzZWxmc2lnbmVkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAMS856cUwkeE\nrqtE+IyfzSFHECkKsOw35xQTNo3u32IjbwzykzOC2x+Pvyh47U3DXM52wPzi3uiL\n+GB4WOtEL0cCAwEAATANBgkqhkiG9w0BAQsFAANBAIIrGyaQCLIqCutaICJbdbIN\nmUzVkrY1iFLRVrfSZ37Ush1sxqpr/YHRf+apHMRXHlITuBrU8HIZbYEiaJUP718=\n");
+    }
+
+    @Test
+    @Ignore("currently failing")
+    public void testCertLoadingWithTextualPreamble() {
+        MatchingServiceAdapterModule matchingServiceAdapterModule = new MatchingServiceAdapterModule();
+        final Certificate certificateWithText = matchingServiceAdapterModule.cert("test cert", "Some text before the cert\n" + CERT, uk.gov.ida.common.shared.security.Certificate.KeyUse.Signing);
+        assertThat(certificateWithText.getCertificate()).isEqualTo("MIIBGzCBxgIJAL0noY5tc8OPMA0GCSqGSIb3DQEBCwUAMBUxEzARBgNVBAMMCnNlbGZzaWduZWQwHhcNMTgwODIzMDY1MzM2WhcNMTkwODIzMDY1MzM2WjAVMRMwEQYDVQQDDApzZWxmc2lnbmVkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAMS856cUwkeErqtE+IyfzSFHECkKsOw35xQTNo3u32IjbwzykzOC2x+Pvyh47U3DXM52wPzi3uiL+GB4WOtEL0cCAwEAATANBgkqhkiG9w0BAQsFAANBAIIrGyaQCLIqCutaICJbdbINmUzVkrY1iFLRVrfSZ37Ush1sxqpr/YHRf+apHMRXHlITuBrU8HIZbYEiaJUP718=");
+    }
+}

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModuleTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModuleTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.matchingserviceadapter;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.ida.common.shared.security.Certificate;
 
@@ -14,13 +13,8 @@ public class MatchingServiceAdapterModuleTest {
     public void testCertLoading() {
         MatchingServiceAdapterModule matchingServiceAdapterModule = new MatchingServiceAdapterModule();
         final Certificate certificate = matchingServiceAdapterModule.cert("test cert", CERT, uk.gov.ida.common.shared.security.Certificate.KeyUse.Signing);
-        assertThat(certificate.getCertificate()).isEqualTo("\nMIIBGzCBxgIJAL0noY5tc8OPMA0GCSqGSIb3DQEBCwUAMBUxEzARBgNVBAMMCnNl\nbGZzaWduZWQwHhcNMTgwODIzMDY1MzM2WhcNMTkwODIzMDY1MzM2WjAVMRMwEQYD\nVQQDDApzZWxmc2lnbmVkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAMS856cUwkeE\nrqtE+IyfzSFHECkKsOw35xQTNo3u32IjbwzykzOC2x+Pvyh47U3DXM52wPzi3uiL\n+GB4WOtEL0cCAwEAATANBgkqhkiG9w0BAQsFAANBAIIrGyaQCLIqCutaICJbdbIN\nmUzVkrY1iFLRVrfSZ37Ush1sxqpr/YHRf+apHMRXHlITuBrU8HIZbYEiaJUP718=\n");
-    }
+        assertThat(certificate.getCertificate()).isEqualTo("MIIBGzCBxgIJAL0noY5tc8OPMA0GCSqGSIb3DQEBCwUAMBUxEzARBgNVBAMMCnNlbGZzaWduZWQwHhcNMTgwODIzMDY1MzM2WhcNMTkwODIzMDY1MzM2WjAVMRMwEQYDVQQDDApzZWxmc2lnbmVkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAMS856cUwkeErqtE+IyfzSFHECkKsOw35xQTNo3u32IjbwzykzOC2x+Pvyh47U3DXM52wPzi3uiL+GB4WOtEL0cCAwEAATANBgkqhkiG9w0BAQsFAANBAIIrGyaQCLIqCutaICJbdbINmUzVkrY1iFLRVrfSZ37Ush1sxqpr/YHRf+apHMRXHlITuBrU8HIZbYEiaJUP718=");
 
-    @Test
-    @Ignore("currently failing")
-    public void testCertLoadingWithTextualPreamble() {
-        MatchingServiceAdapterModule matchingServiceAdapterModule = new MatchingServiceAdapterModule();
         final Certificate certificateWithText = matchingServiceAdapterModule.cert("test cert", "Some text before the cert\n" + CERT, uk.gov.ida.common.shared.security.Certificate.KeyUse.Signing);
         assertThat(certificateWithText.getCertificate()).isEqualTo("MIIBGzCBxgIJAL0noY5tc8OPMA0GCSqGSIb3DQEBCwUAMBUxEzARBgNVBAMMCnNlbGZzaWduZWQwHhcNMTgwODIzMDY1MzM2WhcNMTkwODIzMDY1MzM2WjAVMRMwEQYDVQQDDApzZWxmc2lnbmVkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAMS856cUwkeErqtE+IyfzSFHECkKsOw35xQTNo3u32IjbwzykzOC2x+Pvyh47U3DXM52wPzi3uiL+GB4WOtEL0cCAwEAATANBgkqhkiG9w0BAQsFAANBAIIrGyaQCLIqCutaICJbdbINmUzVkrY1iFLRVrfSZ37Ush1sxqpr/YHRf+apHMRXHlITuBrU8HIZbYEiaJUP718=");
     }


### PR DESCRIPTION
Is this a good idea?

Stop trying to convert certificates with the Java equivalent of 'grep -v'.
Instead, fully parse the certificate and then use conversion routines to get
the output format we desire.

In this case, we want the DER representation of the certificate, base64-encoded

closes #96