### PR TITLE
Update jackson-databind library to fix High Severity vulnerabilities.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ dependencies {
         'javax.inject:javax.inject:1',
         'javax.validation:validation-api:1.1.0.Final',
         'com.fasterxml.jackson.core:jackson-annotations:2.6.0',
-        'com.fasterxml.jackson.core:jackson-databind:2.6.7',
+        'com.fasterxml.jackson.core:jackson-databind:2.9.7',
         'com.google.guava:guava:18.0',
         'com.google.inject:guice:3.0',
         'joda-time:joda-time:2.9',


### PR DESCRIPTION
  https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72448
  https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72449
  https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72450
  https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72451

These vulns were identified by running `snyk test --file=build.gradle`.

(Note that the web interface to Snyk incorrectly resolves our Gradle dependencies, so reports a bunch of other vulnerabilities.)

Still, the command line also reports other libs need updating too (they are just more complicated to upgrade) so I will raise a separate ticket about that.
