### PR TITLE
EID-713 Clean up

### DIFF
--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -58,7 +58,7 @@ import uk.gov.ida.matchingserviceadapter.validators.ConditionsValidator;
 import uk.gov.ida.matchingserviceadapter.validators.DateTimeComparator;
 import uk.gov.ida.matchingserviceadapter.validators.InstantValidator;
 import uk.gov.ida.matchingserviceadapter.validators.SubjectValidator;
-import uk.gov.ida.matchingserviceadapter.validators.TimeRestrictionValidator;
+import uk.gov.ida.matchingserviceadapter.validators.AssertionTimeRestrictionValidator;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import uk.gov.ida.saml.core.api.CoreTransformersFactory;
 import uk.gov.ida.saml.core.domain.AddressFactory;
@@ -130,11 +130,10 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
         bind(AttributeQuerySignatureValidator.class);
         bind(InstantValidator.class);
-        bind(TimeRestrictionValidator.class);
+        bind(AssertionTimeRestrictionValidator.class);
         bind(SubjectValidator.class);
         bind(AudienceRestrictionValidator.class);
         bind(ConditionsValidator.class);
-        //bind(AttributeQueryService.class);
 
         bind(PublicKeyInputStreamFactory.class).to(PublicKeyFileInputStreamFactory.class).in(Singleton.class);
         bind(AssertionLifetimeConfiguration.class).to(MatchingServiceAdapterConfiguration.class).in(Singleton.class);

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
@@ -65,29 +65,29 @@ public class EidasAssertionService extends AssertionService {
     @Override
     public AssertionData translate(List<Assertion> assertions) {
         Assertion countryAssertion = assertions
-                .stream()
-                .filter(this::isCountryAssertion)
-                .findFirst()
-                .orElseThrow(() -> new SamlResponseValidationException("No matching dataset assertion present."));
+            .stream()
+            .filter(this::isCountryAssertion)
+            .findFirst()
+            .orElseThrow(() -> new SamlResponseValidationException("No matching dataset assertion present."));
         Optional<Assertion> cycle3Assertion = assertions.stream()
-                .filter(a -> !isCountryAssertion(a))
-                .findFirst();
+            .filter(a -> !isCountryAssertion(a))
+            .findFirst();
 
         AuthnStatement authnStatement = countryAssertion.getAuthnStatements().get(0);
         String levelOfAssurance = authnStatement.getAuthnContext().getAuthnContextClassRef().getAuthnContextClassRef();
         return new AssertionData(countryAssertion.getIssuer().getValue(),
-                authnContextFactory.mapFromEidasToLoA(levelOfAssurance),
-                getCycle3Data(cycle3Assertion),
-                matchingDatasetUnmarshaller.fromAssertion(countryAssertion));
+            authnContextFactory.mapFromEidasToLoA(levelOfAssurance),
+            getCycle3Data(cycle3Assertion),
+            matchingDatasetUnmarshaller.fromAssertion(countryAssertion));
     }
 
     private void validateCountryAssertion(Assertion assertion, String expectedInResponseTo) {
         metadataResolverRepository.getSignatureTrustEngine(assertion.getIssuer().getValue())
-                .map(MetadataBackedSignatureValidator::withoutCertificateChainValidation)
-                .map(SamlMessageSignatureValidator::new)
-                .map(SamlAssertionsSignatureValidator::new)
-                .orElseThrow(() -> new SamlResponseValidationException("Unable to find metadata resolver for entity Id " + assertion.getIssuer().getValue()))
-                .validate(singletonList(assertion), IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+            .map(MetadataBackedSignatureValidator::withoutCertificateChainValidation)
+            .map(SamlMessageSignatureValidator::new)
+            .map(SamlAssertionsSignatureValidator::new)
+            .orElseThrow(() -> new SamlResponseValidationException("Unable to find metadata resolver for entity Id " + assertion.getIssuer().getValue()))
+            .validate(singletonList(assertion), IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
         instantValidator.validate(assertion.getIssueInstant(), "Country Assertion IssueInstant");
         subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
         conditionsValidator.validate(assertion.getConditions(), hubConnectorEntityId);

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/AssertionTimeRestrictionValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/AssertionTimeRestrictionValidator.java
@@ -8,12 +8,12 @@ import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationExcept
 import static org.joda.time.DateTimeZone.UTC;
 import static org.joda.time.format.ISODateTimeFormat.dateHourMinuteSecond;
 
-public class TimeRestrictionValidator {
+public class AssertionTimeRestrictionValidator {
 
     private final DateTimeComparator dateTimeComparator;
 
     @Inject
-    public TimeRestrictionValidator(DateTimeComparator dateTimeComparator) {
+    public AssertionTimeRestrictionValidator(DateTimeComparator dateTimeComparator) {
         this.dateTimeComparator = dateTimeComparator;
     }
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ConditionsValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ConditionsValidator.java
@@ -8,12 +8,12 @@ import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationExcept
 
 public class ConditionsValidator {
 
-    private final TimeRestrictionValidator timeRestrictionValidator;
+    private final AssertionTimeRestrictionValidator timeRestrictionValidator;
     private final AudienceRestrictionValidator audienceRestrictionValidator;
 
     @Inject
     public ConditionsValidator(
-            TimeRestrictionValidator timeRestrictionValidator,
+            AssertionTimeRestrictionValidator timeRestrictionValidator,
             AudienceRestrictionValidator audienceRestrictionValidator
     ) {
         this.timeRestrictionValidator = timeRestrictionValidator;

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/SubjectValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/SubjectValidator.java
@@ -11,10 +11,10 @@ import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationExcept
 import java.util.stream.Stream;
 
 public class SubjectValidator {
-    TimeRestrictionValidator timeRestrictionValidator;
+    AssertionTimeRestrictionValidator timeRestrictionValidator;
 
     @Inject
-    public SubjectValidator(TimeRestrictionValidator timeRestrictionValidator) {
+    public SubjectValidator(AssertionTimeRestrictionValidator timeRestrictionValidator) {
         this.timeRestrictionValidator = timeRestrictionValidator;
     }
 

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserResponseGeneratorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/controllogic/UnknownUserResponseGeneratorTest.java
@@ -18,7 +18,6 @@ import uk.gov.ida.matchingserviceadapter.domain.OutboundResponseFromUnknownUserC
 import uk.gov.ida.matchingserviceadapter.domain.UserAccountCreationAttribute;
 import uk.gov.ida.matchingserviceadapter.domain.UserAccountCreationAttributeExtractor;
 import uk.gov.ida.matchingserviceadapter.rest.UnknownUserCreationResponseDto;
-import uk.gov.ida.matchingserviceadapter.saml.UserIdHashFactory;
 import uk.gov.ida.matchingserviceadapter.services.UnknownUserResponseGenerator;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import uk.gov.ida.saml.core.domain.AuthnContext;
@@ -77,15 +76,8 @@ public class UnknownUserResponseGeneratorTest {
     @Mock
     private AssertionLifetimeConfiguration assertionLifetimeConfiguration;
 
-    @Mock
-    private UserIdHashFactory userIdHashFactory;
-
     private UnknownUserResponseGenerator unknownUserResponseGenerator;
 
-    private String hashedPid = "hashedPid";
-    private String issuerId = "some-idp";
-    private String nameId = "nameId";
-    private AuthnContext authnContext = AuthnContext.LEVEL_2;
     private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
 
     @Before

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/saml/factories/UserAccountCreationAttributeFactoryTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/saml/factories/UserAccountCreationAttributeFactoryTest.java
@@ -1,0 +1,111 @@
+package uk.gov.ida.matchingserviceadapter.saml.factories;
+
+
+import org.joda.time.LocalDate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Attribute;
+import uk.gov.ida.matchingserviceadapter.builders.AddressBuilder;
+import uk.gov.ida.matchingserviceadapter.builders.SimpleMdsValueBuilder;
+import uk.gov.ida.matchingserviceadapter.domain.UserAccountCreationAttribute;
+import uk.gov.ida.saml.core.domain.Address;
+import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.extensions.impl.AddressImpl;
+import uk.gov.ida.saml.core.extensions.impl.StringBasedMdsAttributeValueImpl;
+import uk.gov.ida.saml.core.extensions.impl.StringValueSamlObjectImpl;
+import uk.gov.ida.saml.core.extensions.impl.VerifiedImpl;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(OpenSAMLRunner.class)
+public class UserAccountCreationAttributeFactoryTest {
+
+    private final UserAccountCreationAttributeFactory factory = new UserAccountCreationAttributeFactory(new OpenSamlXmlObjectFactory());
+
+    @Test
+    public void firstNameAttribute() {
+        assertSimpleMdsAttribute(factory::createUserAccountCreationFirstNameAttribute, "firstname", "Joe");
+    }
+
+    @Test
+    public void middleNameAttribute() {
+        assertSimpleMdsAttribute(factory::createUserAccountCreationMiddleNameAttribute, "middlename", "John");
+    }
+
+    @Test
+    public void surnameAttribute() {
+        assertSimpleMdsAttribute(factory::createUserAccountCreationSurnameAttribute, "surname", "Bloggs");
+    }
+
+    @Test
+    public void dateOfBirthAttribute() {
+        assertSimpleMdsAttribute(factory::createUserAccountCreationDateOfBirthAttribute, "dateofbirth", LocalDate.parse("2016-04-29"));
+    }
+
+    @Test
+    public void currentAddressAttribute() {
+        Address address = AddressBuilder.aCurrentAddress().withPostCode("HD7 5UZ").build();
+        Attribute addressAttribute = factory.createUserAccountCreationCurrentAddressAttribute(address);
+
+        assertThat(addressAttribute.getName()).isEqualTo("currentaddress");
+        AddressImpl castXMLObject = (AddressImpl) addressAttribute.getAttributeValues().get(0);
+        assertThat(castXMLObject.getPostCode().getValue()).isEqualTo("HD7 5UZ");
+    }
+
+    @Test
+    public void addressHistoryAttribute() {
+        List<Address> historicalAddresses = new ArrayList<>();
+        String[] postcodes = {"SW1A 0AA", "SW1A 1AA", "SW1A 2AA"};
+        for (String postcode : postcodes) {
+            historicalAddresses.add(AddressBuilder.aHistoricalAddress().withPostCode(postcode).build());
+        }
+        Attribute addressHistoryAttribute = factory.createUserAccountCreationAddressHistoryAttribute(historicalAddresses);
+
+        assertThat(addressHistoryAttribute.getName()).isEqualTo("addresshistory");
+        for (int i=0; i<3; i++) {
+            AddressImpl castXMLObject = (AddressImpl) addressHistoryAttribute.getAttributeValues().get(i);
+            assertThat(castXMLObject.getPostCode().getValue()).isEqualTo(String.format("SW1A %dAA", i));
+        }
+    }
+
+    @Test
+    public void verifiedAttribute() {
+        Attribute verifiedAttribute = factory.createUserAccountCreationVerifiedAttribute(UserAccountCreationAttribute.FIRST_NAME, true);
+
+        assertThat(verifiedAttribute.getName()).isEqualTo("firstname");
+        VerifiedImpl castXMLObject = (VerifiedImpl) verifiedAttribute.getAttributeValues().get(0);
+        assertThat(castXMLObject.getValue()).isTrue();
+    }
+
+    @Test
+    public void cycle3DataAttributes() {
+        List<String> attributes = Arrays.asList("Attribute 0", "Attribute 1", "Attribute 2");
+        Attribute cycle3DataAttributes = factory.createUserAccountCreationCycle3DataAttributes(attributes);
+
+        assertThat(cycle3DataAttributes.getName()).isEqualTo("cycle_3");
+        for (int i=0; i<3; i++) {
+            StringBasedMdsAttributeValueImpl castXMLObject = (StringBasedMdsAttributeValueImpl) cycle3DataAttributes.getAttributeValues().get(i);
+            assertThat(castXMLObject.getValue()).isEqualTo(String.format("Attribute %d", i));
+        }
+    }
+
+    private <T, E extends StringValueSamlObjectImpl> void assertSimpleMdsAttribute(
+                Function<SimpleMdsValue<T>, Attribute> attributeFunction,
+                String attributeName,
+                T attributeValue) {
+        SimpleMdsValue<T> mdsValue = SimpleMdsValueBuilder.<T>aCurrentSimpleMdsValue().withValue(attributeValue).build();
+        Attribute attribute = attributeFunction.apply(mdsValue);
+
+        assertThat(attribute.getName()).isEqualTo(attributeName);
+        E attributeValueAsType = (E) attribute.getAttributeValues().get(0);
+        assertThat(attributeValueAsType.getValue()).isEqualTo(attributeValue.toString());
+    }
+
+}

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/UnknownUserResponseGeneratorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/UnknownUserResponseGeneratorTest.java
@@ -18,7 +18,6 @@ import uk.gov.ida.matchingserviceadapter.domain.OutboundResponseFromUnknownUserC
 import uk.gov.ida.matchingserviceadapter.domain.UserAccountCreationAttribute;
 import uk.gov.ida.matchingserviceadapter.domain.UserAccountCreationAttributeExtractor;
 import uk.gov.ida.matchingserviceadapter.rest.UnknownUserCreationResponseDto;
-import uk.gov.ida.matchingserviceadapter.saml.UserIdHashFactory;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import uk.gov.ida.saml.core.domain.AuthnContext;
 import uk.gov.ida.saml.core.domain.Cycle3Dataset;
@@ -76,15 +75,8 @@ public class UnknownUserResponseGeneratorTest {
     @Mock
     private AssertionLifetimeConfiguration assertionLifetimeConfiguration;
 
-    @Mock
-    private UserIdHashFactory userIdHashFactory;
-
     private UnknownUserResponseGenerator unknownUserResponseGenerator;
 
-    private String hashedPid = "hashedPid";
-    private String issuerId = "some-idp";
-    private String nameId = "nameId";
-    private AuthnContext authnContext = AuthnContext.LEVEL_2;
     private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
 
     @Before

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validator/AttributeQuerySignatureValidatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validator/AttributeQuerySignatureValidatorTest.java
@@ -3,16 +3,13 @@ package uk.gov.ida.matchingserviceadapter.validator;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensaml.saml.saml2.core.AttributeQuery;
-import org.opensaml.saml.saml2.core.RequestAbstractType;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
-import org.slf4j.event.Level;
 import uk.gov.ida.matchingserviceadapter.validators.AttributeQuerySignatureValidator;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationResponse;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 import uk.gov.ida.saml.security.SamlMessageSignatureValidator;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,15 +18,10 @@ public class AttributeQuerySignatureValidatorTest {
     private AttributeQuerySignatureValidator validator;
     private SamlMessageSignatureValidator samlMessageSignatureValidator;
 
-//    @Rule
-//    public ExpectedException expectedException = ExpectedException.none();
-
-
     @Before
     public void setUp() {
 
         samlMessageSignatureValidator = mock(SamlMessageSignatureValidator.class);
-        //IdaSamlBootstrap.bootstrap();
     }
 
     @Test

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validator/ConditionsValidatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validator/ConditionsValidatorTest.java
@@ -13,7 +13,7 @@ import org.opensaml.saml.saml2.core.ProxyRestriction;
 import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
 import uk.gov.ida.matchingserviceadapter.validators.AudienceRestrictionValidator;
 import uk.gov.ida.matchingserviceadapter.validators.ConditionsValidator;
-import uk.gov.ida.matchingserviceadapter.validators.TimeRestrictionValidator;
+import uk.gov.ida.matchingserviceadapter.validators.AssertionTimeRestrictionValidator;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 
 import java.util.List;
@@ -23,7 +23,7 @@ import static uk.gov.ida.saml.core.test.builders.AudienceRestrictionBuilder.anAu
 
 public class ConditionsValidatorTest {
 
-    private TimeRestrictionValidator timeRestrictionValidator;
+    private AssertionTimeRestrictionValidator timeRestrictionValidator;
     private AudienceRestrictionValidator audienceRestrictionValidator;
     private Conditions conditions;
 
@@ -34,7 +34,7 @@ public class ConditionsValidatorTest {
 
     @Before
     public void setUp() {
-        timeRestrictionValidator = mock(TimeRestrictionValidator.class);
+        timeRestrictionValidator = mock(AssertionTimeRestrictionValidator.class);
         audienceRestrictionValidator = mock(AudienceRestrictionValidator.class);
         conditions = mock(Conditions.class);
 

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validator/SubjectValidatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validator/SubjectValidatorTest.java
@@ -11,7 +11,7 @@ import org.opensaml.saml.saml2.core.Subject;
 import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
 import uk.gov.ida.matchingserviceadapter.validators.SubjectValidator;
-import uk.gov.ida.matchingserviceadapter.validators.TimeRestrictionValidator;
+import uk.gov.ida.matchingserviceadapter.validators.AssertionTimeRestrictionValidator;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 
 import static uk.gov.ida.saml.core.test.builders.NameIdBuilder.aNameId;
@@ -28,7 +28,7 @@ public class SubjectValidatorTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Mock
-    private TimeRestrictionValidator timeRestrictionValidator;
+    private AssertionTimeRestrictionValidator timeRestrictionValidator;
 
     @Before
     public void setUp() {

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validator/TimeRestrictionValidatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validator/TimeRestrictionValidatorTest.java
@@ -8,18 +8,17 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
 import uk.gov.ida.matchingserviceadapter.validators.DateTimeComparator;
-import uk.gov.ida.matchingserviceadapter.validators.TimeRestrictionValidator;
+import uk.gov.ida.matchingserviceadapter.validators.AssertionTimeRestrictionValidator;
 
 import static org.joda.time.DateTimeZone.UTC;
 import static org.joda.time.format.ISODateTimeFormat.dateHourMinuteSecond;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class TimeRestrictionValidatorTest {
 
     private DateTimeComparator dateTimeComparator;
 
-    private TimeRestrictionValidator validator;
+    private AssertionTimeRestrictionValidator validator;
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -28,7 +27,7 @@ public class TimeRestrictionValidatorTest {
     public void setUp() {
         dateTimeComparator = new DateTimeComparator(new Duration(5000)  );
 
-        validator = new TimeRestrictionValidator(dateTimeComparator);
+        validator = new AssertionTimeRestrictionValidator(dateTimeComparator);
     }
 
     @Test


### PR DESCRIPTION
This commit cleans up a few things, such as whitespace and unused
imports.

It's also adds some tests for UserAccountCreationAttributeFatory, and
extends some tests for EidasAssertionServiceTest.