### PR TITLE
EID-1072 Pull in build 68 of saml-libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ def dependencyVersions = [
         hub_saml: "$opensaml-15701",
         dev_pki: '1.1.0-34',
         trust_anchor: '1.0-34',
-        saml_libs_version: "$opensaml-162"
+        saml_libs_version: "$opensaml-168"
 ]
 
 repositories {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterApplication.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterApplication.java
@@ -18,6 +18,7 @@ import uk.gov.ida.bundles.LoggingBundle;
 import uk.gov.ida.bundles.MonitoringBundle;
 import uk.gov.ida.bundles.ServiceStatusBundle;
 import uk.gov.ida.matchingserviceadapter.exceptions.ExceptionExceptionMapper;
+import uk.gov.ida.matchingserviceadapter.exceptions.MissingMetadataException;
 import uk.gov.ida.matchingserviceadapter.exceptions.SamlOverSoapExceptionMapper;
 import uk.gov.ida.matchingserviceadapter.healthcheck.MatchingServiceAdapterHealthCheck;
 import uk.gov.ida.matchingserviceadapter.resources.LocalMetadataResource;
@@ -105,8 +106,6 @@ public class MatchingServiceAdapterApplication extends Application<MatchingServi
         environment.jersey().register(SamlOverSoapExceptionMapper.class);
         environment.jersey().register(ExceptionExceptionMapper.class);
 
-
-        environment.healthChecks().register("VerifyMetadataHealthCheck", new MetadataHealthCheck(metadataResolverBundle.getMetadataResolver(), configuration.getMetadataConfiguration().getExpectedEntityId()));
         registerMetadataRefreshTask(environment, Optional.empty(), ImmutableList.of(metadataResolverBundle.getMetadataResolver()), "metadata");
 
         MatchingServiceAdapterHealthCheck healthCheck = new MatchingServiceAdapterHealthCheck();

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
@@ -14,13 +14,14 @@ import uk.gov.ida.matchingserviceadapter.configuration.LocalMatchingServiceConfi
 import uk.gov.ida.matchingserviceadapter.configuration.MatchingServiceAdapterMetadataConfiguration;
 import uk.gov.ida.matchingserviceadapter.configuration.ServiceInfo;
 import uk.gov.ida.matchingserviceadapter.configuration.SigningKeysConfiguration;
-import uk.gov.ida.saml.metadata.MetadataConfiguration;
+import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 @SuppressWarnings("unused")
 public class MatchingServiceAdapterConfiguration extends Configuration implements AssertionLifetimeConfiguration, ServiceNameConfiguration {
@@ -122,8 +123,8 @@ public class MatchingServiceAdapterConfiguration extends Configuration implement
         return localMatchingService.getClient();
     }
 
-    public MetadataConfiguration getMetadataConfiguration() {
-        return metadata;
+    public Optional<MetadataResolverConfiguration> getMetadataConfiguration() {
+        return Optional.of(metadata);
     }
 
     public List<KeyPairConfiguration> getSigningKeys() {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -38,6 +38,7 @@ import uk.gov.ida.matchingserviceadapter.domain.OutboundResponseFromUnknownUserC
 import uk.gov.ida.matchingserviceadapter.domain.UserAccountCreationAttributeExtractor;
 import uk.gov.ida.matchingserviceadapter.exceptions.ExceptionResponseFactory;
 import uk.gov.ida.matchingserviceadapter.exceptions.InvalidCertificateException;
+import uk.gov.ida.matchingserviceadapter.exceptions.MissingMetadataException;
 import uk.gov.ida.matchingserviceadapter.mappers.MatchingDatasetToMatchingDatasetDtoMapper;
 import uk.gov.ida.matchingserviceadapter.mappers.MatchingServiceRequestDtoMapper;
 import uk.gov.ida.matchingserviceadapter.mappers.MatchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper;
@@ -72,8 +73,8 @@ import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
 import uk.gov.ida.saml.metadata.EidasTrustAnchorHealthCheck;
 import uk.gov.ida.saml.metadata.EidasTrustAnchorResolver;
 import uk.gov.ida.saml.metadata.ExpiredCertificateMetadataFilter;
-import uk.gov.ida.saml.metadata.MetadataConfiguration;
 import uk.gov.ida.saml.metadata.MetadataResolverConfigBuilder;
+import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 import uk.gov.ida.saml.metadata.MetadataResolverRepository;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
 import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
@@ -302,7 +303,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
     @Singleton
     @Named("HubFederationId")
     public String getHubFederationId(MatchingServiceAdapterConfiguration configuration) {
-        return configuration.getMetadataConfiguration().getHubFederationId();
+        return configuration.getMetadataConfiguration().orElseThrow(() -> new MissingMetadataException()).getHubFederationId();
     }
 
     @Provides
@@ -460,7 +461,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public MetadataConfiguration metadataConfiguration(MatchingServiceAdapterConfiguration msaConfiguration) {
+    public Optional<MetadataResolverConfiguration> metadataConfiguration(MatchingServiceAdapterConfiguration msaConfiguration) {
         return msaConfiguration.getMetadataConfiguration();
     }
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/MissingMetadataException.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/MissingMetadataException.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.matchingserviceadapter.exceptions;
+
+public class MissingMetadataException extends RuntimeException {
+    public MissingMetadataException() {
+        super();
+    }
+}


### PR DESCRIPTION
I wasn't sure how to test these changes as two of them require testing the start up behaviour of app, and the other tests behaviour that won't happen (missing metadata).

It does three things.

Updates `EidasMetadataResolverRepository` to throw an Exception instead
of an Error if it encounters and expired cert in the trust anchor. This
will allow the MSA to startup, rather than crashing.

The MedataResolverBundle now sets up the metadata healthcheck, so the
one registered in the Application class can be removed.

Makes metadata bundling optional. This requires an update to the
configuration class, specifically `getMetadataConfiguration` to return
an Optional. The MSA config annotates the metadata with `@NotNull` so we
should never get a null optional, however `orElseThrow` has been added
in certain places with a new Exception to be on the safe side.