### PR TITLE
AUTO-340: Fix keepAlive issue

### DIFF
--- a/src/integration-test/java/uk/gov/ida/integrationtest/helpers/MatchingServiceAdapterAppRule.java
+++ b/src/integration-test/java/uk/gov/ida/integrationtest/helpers/MatchingServiceAdapterAppRule.java
@@ -34,8 +34,6 @@ import javax.ws.rs.core.MediaType;
 import java.security.PrivateKey;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
@@ -158,7 +158,7 @@ public class MatchingServiceAdapterConfiguration extends Configuration implement
         jerseyClientConfiguration.setCookiesEnabled(false);
         jerseyClientConfiguration.setConnectionTimeout(Duration.seconds(4));
         jerseyClientConfiguration.setRetries(3);
-        jerseyClientConfiguration.setKeepAlive(Duration.seconds(60));
+        jerseyClientConfiguration.setKeepAlive(Duration.seconds(10));
         jerseyClientConfiguration.setChunkedEncodingEnabled(false);
         jerseyClientConfiguration.setValidateAfterInactivityPeriod(Duration.seconds(5));
         TlsConfiguration tlsConfiguration = new TlsConfiguration();


### PR DESCRIPTION
The keepAlive value determines how long a persistent connection is kept open on the client side without being used (between two http requests). This value must be set less than the server side idleTimeout (defaults to 30 seconds in Dropwizard server) otherwise the connection can be closed on the server’s end resulting a org.apache.http.NoHttpResponseException when the client tries to reuse the connection.

SAML SOAP Proxy HTTP client, SAML SOAP Proxy MSA client and SAML SOAP Proxy MSA HealthCheck client had keepAlive set to 60 seconds. SAML Engine server's and MSA server's idleTimeout defaulted to 30 seconds. The clients' keepAlive were greater than the servers' idleTimeout. There were 5,422 org.apache.http.NoHttpResponseException in SAML SOAP Proxy log file in production over the last 7 days via Kibana. I changed keepAlive to 10 seconds instead of 60 seconds so that it was less than the server's idleTimeout. As a result of this change, the number of org.apache.http.NoHttpResponseException stopped appearing in SAML SOAP Proxy log file.

<img width="1362" alt="SAMLSOAPProxyLogFile" src="https://user-images.githubusercontent.com/19972046/55388871-ff7f5380-552b-11e9-8e4b-cb981f6970c5.png">

MSA has the same issue. This commit updates its client keep alive set to 10 seconds instead of 60 seconds. This will stop the application from throwing org.apache.http.NoHttpResponseException.

Author: @adityapahuja