### PR TITLE
Use verify-saml-libs compiled using openjdk-11 but with java 8 compile target

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ def dependencyVersions = [
         ida_test_utils: '44',
         dev_pki: '1.1.0-34',
         trust_anchor: '1.0-34',
-        saml_libs_version: "$opensaml-186"
+        saml_libs_version: "$opensaml-192"
 ]
 
 repositories {


### PR DESCRIPTION
Builds of `verify-saml-libs` >= `188` are compiled using OpenJDK-11.

`verify-matching-service-adapter` is still compiled for Java 8, which will produce a compiler error like:
`class file has wrong version 55.0, should be 52.0`, when trying to compile in a `verify-saml-libs` dependency >= 188.

This PR uses a build of `verify-saml-libs` with compile target set to `1.8` to avoid this compile error.

The travis build for the project compiles against `oraclejdk8` and `openjdk8`, which will help validate the change.

This PR follow on from https://github.com/alphagov/verify-saml-libs/pull/63



