### PR TITLE
EID-888 Make sure one time validation works for EIDAS in the MSA

### DIFF
--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -55,7 +55,8 @@ import uk.gov.ida.matchingserviceadapter.services.UnknownUserResponseGenerator;
 import uk.gov.ida.matchingserviceadapter.services.VerifyAssertionService;
 import uk.gov.ida.matchingserviceadapter.validators.AttributeQuerySignatureValidator;
 import uk.gov.ida.matchingserviceadapter.validators.AudienceRestrictionValidator;
-import uk.gov.ida.matchingserviceadapter.validators.ConditionsValidator;
+import uk.gov.ida.matchingserviceadapter.validators.EidasConditionsValidator;
+import uk.gov.ida.matchingserviceadapter.validators.VerifyConditionsValidator;
 import uk.gov.ida.matchingserviceadapter.validators.DateTimeComparator;
 import uk.gov.ida.matchingserviceadapter.validators.InstantValidator;
 import uk.gov.ida.matchingserviceadapter.validators.SubjectValidator;
@@ -134,7 +135,8 @@ class MatchingServiceAdapterModule extends AbstractModule {
         bind(AssertionTimeRestrictionValidator.class);
         bind(SubjectValidator.class);
         bind(AudienceRestrictionValidator.class);
-        bind(ConditionsValidator.class);
+        bind(VerifyConditionsValidator.class);
+        bind(EidasConditionsValidator.class);
 
         bind(PublicKeyInputStreamFactory.class).to(PublicKeyFileInputStreamFactory.class).in(Singleton.class);
         bind(AssertionLifetimeConfiguration.class).to(MatchingServiceAdapterConfiguration.class).in(Singleton.class);
@@ -217,7 +219,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
     public VerifyAssertionService getVerifyAssertionService(
             InstantValidator instantValidator,
             SubjectValidator subjectValidator,
-            ConditionsValidator conditionsValidator,
+            VerifyConditionsValidator conditionsValidator,
             SamlAssertionsSignatureValidator signatureValidator,
             Cycle3DatasetFactory cycle3DatasetFactory,
             VerifyMatchingDatasetUnmarshaller matchingDatasetUnmarshaller,
@@ -244,7 +246,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
     public EidasAssertionService getCountryAssertionService(
             InstantValidator instantValidator,
             SubjectValidator subjectValidator,
-            ConditionsValidator conditionsValidator,
+            EidasConditionsValidator conditionsValidator,
             SamlAssertionsSignatureValidator hubSignatureValidator,
             Cycle3DatasetFactory cycle3DatasetFactory,
             MetadataResolverRepository eidasMetadataRepository,

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/AssertionService.java
@@ -6,6 +6,7 @@ import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import uk.gov.ida.matchingserviceadapter.domain.AssertionData;
 import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
 import uk.gov.ida.matchingserviceadapter.validators.ConditionsValidator;
+import uk.gov.ida.matchingserviceadapter.validators.VerifyConditionsValidator;
 import uk.gov.ida.matchingserviceadapter.validators.InstantValidator;
 import uk.gov.ida.matchingserviceadapter.validators.SubjectValidator;
 import uk.gov.ida.saml.core.domain.Cycle3Dataset;

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
@@ -5,7 +5,7 @@ import org.opensaml.saml.saml2.core.AuthnStatement;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import uk.gov.ida.matchingserviceadapter.domain.AssertionData;
 import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
-import uk.gov.ida.matchingserviceadapter.validators.ConditionsValidator;
+import uk.gov.ida.matchingserviceadapter.validators.EidasConditionsValidator;
 import uk.gov.ida.matchingserviceadapter.validators.InstantValidator;
 import uk.gov.ida.matchingserviceadapter.validators.SubjectValidator;
 import uk.gov.ida.saml.core.transformers.AuthnContextFactory;
@@ -24,7 +24,7 @@ import static java.util.Collections.singletonList;
 
 public class EidasAssertionService extends AssertionService {
 
-    private final ConditionsValidator conditionsValidator;
+    private final EidasConditionsValidator conditionsValidator;
     private final MetadataResolverRepository metadataResolverRepository;
     private final String hubConnectorEntityId;
     private final String hubEntityId;
@@ -34,7 +34,7 @@ public class EidasAssertionService extends AssertionService {
     @Inject
     public EidasAssertionService(InstantValidator instantValidator,
                                  SubjectValidator subjectValidator,
-                                 ConditionsValidator conditionsValidator,
+                                 EidasConditionsValidator conditionsValidator,
                                  SamlAssertionsSignatureValidator hubSignatureValidator,
                                  Cycle3DatasetFactory cycle3DatasetFactory,
                                  MetadataResolverRepository metadataResolverRepository,

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionService.java
@@ -7,7 +7,7 @@ import uk.gov.ida.matchingserviceadapter.domain.AssertionClassification;
 import uk.gov.ida.matchingserviceadapter.domain.AssertionClassifier;
 import uk.gov.ida.matchingserviceadapter.domain.AssertionData;
 import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
-import uk.gov.ida.matchingserviceadapter.validators.ConditionsValidator;
+import uk.gov.ida.matchingserviceadapter.validators.VerifyConditionsValidator;
 import uk.gov.ida.matchingserviceadapter.validators.InstantValidator;
 import uk.gov.ida.matchingserviceadapter.validators.SubjectValidator;
 import uk.gov.ida.saml.core.transformers.AuthnContextFactory;
@@ -36,7 +36,7 @@ public class VerifyAssertionService extends AssertionService {
 
     public VerifyAssertionService(InstantValidator instantValidator,
                                   SubjectValidator subjectValidator,
-                                  ConditionsValidator conditionsValidator,
+                                  VerifyConditionsValidator conditionsValidator,
                                   SamlAssertionsSignatureValidator hubSignatureValidator,
                                   Cycle3DatasetFactory cycle3DatasetFactory,
                                   String hubEntityId,

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ConditionsValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ConditionsValidator.java
@@ -1,44 +1,7 @@
 package uk.gov.ida.matchingserviceadapter.validators;
 
-import com.google.inject.Inject;
-import org.joda.time.DateTime;
 import org.opensaml.saml.saml2.core.Conditions;
-import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
 
-
-public class ConditionsValidator {
-
-    private final AssertionTimeRestrictionValidator timeRestrictionValidator;
-    private final AudienceRestrictionValidator audienceRestrictionValidator;
-
-    @Inject
-    public ConditionsValidator(
-            AssertionTimeRestrictionValidator timeRestrictionValidator,
-            AudienceRestrictionValidator audienceRestrictionValidator
-    ) {
-        this.timeRestrictionValidator = timeRestrictionValidator;
-        this.audienceRestrictionValidator = audienceRestrictionValidator;
-    }
-
-    public void validate(Conditions conditionsElement, String entityId) {
-        if (conditionsElement == null) {
-            throw new SamlResponseValidationException("Conditions is missing from the assertion.");
-        }
-
-        if (conditionsElement.getProxyRestriction() != null) {
-            throw new SamlResponseValidationException("Conditions should not contain proxy restriction element.");
-        }
-
-        if (conditionsElement.getOneTimeUse() != null) {
-            throw new SamlResponseValidationException("Conditions should not contain one time use element.");
-        }
-
-        DateTime notOnOrAfter = conditionsElement.getNotOnOrAfter();
-        if (notOnOrAfter != null) {
-            timeRestrictionValidator.validateNotOnOrAfter(notOnOrAfter);
-        }
-
-        timeRestrictionValidator.validateNotBefore(conditionsElement.getNotBefore());
-        audienceRestrictionValidator.validate(conditionsElement.getAudienceRestrictions(), entityId);
-    }
+public interface ConditionsValidator {
+    void validate(Conditions conditionsElement, String entityId);
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/EidasConditionsValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/EidasConditionsValidator.java
@@ -1,0 +1,38 @@
+package uk.gov.ida.matchingserviceadapter.validators;
+
+import com.google.inject.Inject;
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.Conditions;
+import uk.gov.ida.matchingserviceadapter.validators.ValidationRules.ConditionsElementMustNotBeNull;
+import uk.gov.ida.matchingserviceadapter.validators.ValidationRules.ConditionsShouldNotContainProxyRestrictionElement;
+
+
+public class EidasConditionsValidator implements ConditionsValidator {
+
+    private final AssertionTimeRestrictionValidator timeRestrictionValidator;
+    private final AudienceRestrictionValidator audienceRestrictionValidator;
+
+    @Inject
+    public EidasConditionsValidator(
+            AssertionTimeRestrictionValidator timeRestrictionValidator,
+            AudienceRestrictionValidator audienceRestrictionValidator
+    ) {
+        this.timeRestrictionValidator = timeRestrictionValidator;
+        this.audienceRestrictionValidator = audienceRestrictionValidator;
+    }
+
+    public void validate(Conditions conditionsElement, String entityId) {
+
+        ConditionsElementMustNotBeNull.validate(conditionsElement);
+
+        ConditionsShouldNotContainProxyRestrictionElement.validate(conditionsElement.getProxyRestriction());
+
+        DateTime notOnOrAfter = conditionsElement.getNotOnOrAfter();
+        if (notOnOrAfter != null) {
+            timeRestrictionValidator.validateNotOnOrAfter(notOnOrAfter);
+        }
+
+        timeRestrictionValidator.validateNotBefore(conditionsElement.getNotBefore());
+        audienceRestrictionValidator.validate(conditionsElement.getAudienceRestrictions(), entityId);
+    }
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ValidationRules/ConditionsElementMustNotBeNull.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ValidationRules/ConditionsElementMustNotBeNull.java
@@ -1,0 +1,20 @@
+package uk.gov.ida.matchingserviceadapter.validators.ValidationRules;
+
+import org.opensaml.saml.saml2.core.Conditions;
+import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
+
+public class ConditionsElementMustNotBeNull extends ValidationRule<Conditions> {
+
+    public ConditionsElementMustNotBeNull() {
+        super((e) -> e != null);
+    }
+
+    public static void validate(Conditions conditions) {
+        new ConditionsElementMustNotBeNull().apply(conditions);
+    }
+
+    @Override
+    public void throwException() {
+        throw new SamlResponseValidationException("Conditions is missing from the assertion.");
+    }
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ValidationRules/ConditionsShouldNotContainOneTimeUseElement.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ValidationRules/ConditionsShouldNotContainOneTimeUseElement.java
@@ -1,0 +1,18 @@
+package uk.gov.ida.matchingserviceadapter.validators.ValidationRules;
+
+import org.opensaml.saml.saml2.core.OneTimeUse;
+import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
+
+public class ConditionsShouldNotContainOneTimeUseElement extends ValidationRule<OneTimeUse> {
+    public ConditionsShouldNotContainOneTimeUseElement() {
+        super((e) -> e == null);
+    }
+
+    public static void validate(OneTimeUse oneTimeUse) {
+        new ConditionsShouldNotContainOneTimeUseElement().apply(oneTimeUse);
+    }
+
+    public void throwException() {
+        throw new SamlResponseValidationException("Conditions should not contain one time use element.");
+    }
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ValidationRules/ConditionsShouldNotContainProxyRestrictionElement.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ValidationRules/ConditionsShouldNotContainProxyRestrictionElement.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.matchingserviceadapter.validators.ValidationRules;
+
+import org.opensaml.saml.saml2.core.ProxyRestriction;
+import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
+
+public class ConditionsShouldNotContainProxyRestrictionElement extends ValidationRule<ProxyRestriction> {
+    public ConditionsShouldNotContainProxyRestrictionElement() {
+        super((e) -> e == null);
+    }
+
+    public static void validate(ProxyRestriction proxyRestriction) {
+        new ConditionsShouldNotContainProxyRestrictionElement().apply(proxyRestriction);
+    }
+
+    @Override
+    public void throwException() {
+        throw new SamlResponseValidationException("Conditions should not contain proxy restriction element.");
+    }
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ValidationRules/ValidationRule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/ValidationRules/ValidationRule.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.matchingserviceadapter.validators.ValidationRules;
+
+import java.util.function.Predicate;
+
+public abstract class ValidationRule<T> {
+    private Predicate<T> predicate;
+
+    protected ValidationRule(Predicate<T> predicate) {
+        this.predicate = predicate;
+    }
+
+    protected void apply(T subject) {
+        if (!predicate.test(subject)) {
+            throwException();
+        }
+    }
+
+    public abstract void throwException();
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/validators/VerifyConditionsValidator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/validators/VerifyConditionsValidator.java
@@ -1,0 +1,41 @@
+package uk.gov.ida.matchingserviceadapter.validators;
+
+import com.google.inject.Inject;
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.Conditions;
+import uk.gov.ida.matchingserviceadapter.validators.ValidationRules.ConditionsElementMustNotBeNull;
+import uk.gov.ida.matchingserviceadapter.validators.ValidationRules.ConditionsShouldNotContainOneTimeUseElement;
+import uk.gov.ida.matchingserviceadapter.validators.ValidationRules.ConditionsShouldNotContainProxyRestrictionElement;
+
+
+public class VerifyConditionsValidator implements ConditionsValidator {
+
+    private final AssertionTimeRestrictionValidator timeRestrictionValidator;
+    private final AudienceRestrictionValidator audienceRestrictionValidator;
+
+    @Inject
+    public VerifyConditionsValidator(
+            AssertionTimeRestrictionValidator timeRestrictionValidator,
+            AudienceRestrictionValidator audienceRestrictionValidator
+    ) {
+        this.timeRestrictionValidator = timeRestrictionValidator;
+        this.audienceRestrictionValidator = audienceRestrictionValidator;
+    }
+
+    public void validate(Conditions conditionsElement, String entityId) {
+
+        ConditionsElementMustNotBeNull.validate(conditionsElement);
+
+        ConditionsShouldNotContainProxyRestrictionElement.validate(conditionsElement.getProxyRestriction());
+
+        ConditionsShouldNotContainOneTimeUseElement.validate(conditionsElement.getOneTimeUse());
+
+        DateTime notOnOrAfter = conditionsElement.getNotOnOrAfter();
+        if (notOnOrAfter != null) {
+            timeRestrictionValidator.validateNotOnOrAfter(notOnOrAfter);
+        }
+
+        timeRestrictionValidator.validateNotBefore(conditionsElement.getNotBefore());
+        audienceRestrictionValidator.validate(conditionsElement.getAudienceRestrictions(), entityId);
+    }
+}

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionServiceTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionServiceTest.java
@@ -8,7 +8,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.opensaml.saml.saml2.core.Assertion;
 import uk.gov.ida.matchingserviceadapter.domain.AssertionData;
-import uk.gov.ida.matchingserviceadapter.validators.ConditionsValidator;
+import uk.gov.ida.matchingserviceadapter.validators.EidasConditionsValidator;
+import uk.gov.ida.matchingserviceadapter.validators.VerifyConditionsValidator;
 import uk.gov.ida.matchingserviceadapter.validators.InstantValidator;
 import uk.gov.ida.matchingserviceadapter.validators.SubjectValidator;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
@@ -49,7 +50,7 @@ public class EidasAssertionServiceTest {
     private SubjectValidator subjectValidator;
 
     @Mock
-    private ConditionsValidator conditionsValidator;
+    private EidasConditionsValidator conditionsValidator;
 
     @Mock
     private SamlAssertionsSignatureValidator hubSignatureValidator;

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionServiceTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/VerifyAssertionServiceTest.java
@@ -15,7 +15,7 @@ import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.xmlsec.signature.Signature;
 import uk.gov.ida.matchingserviceadapter.domain.AssertionData;
 import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
-import uk.gov.ida.matchingserviceadapter.validators.ConditionsValidator;
+import uk.gov.ida.matchingserviceadapter.validators.VerifyConditionsValidator;
 import uk.gov.ida.matchingserviceadapter.validators.InstantValidator;
 import uk.gov.ida.matchingserviceadapter.validators.SubjectValidator;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
@@ -70,7 +70,7 @@ public class VerifyAssertionServiceTest {
     private SubjectValidator subjectValidator;
 
     @Mock
-    private ConditionsValidator conditionsValidator;
+    private VerifyConditionsValidator conditionsValidator;
 
     @Mock
     private SamlAssertionsSignatureValidator hubSignatureValidator;

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validator/EidasConditionsValidatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validator/EidasConditionsValidatorTest.java
@@ -1,0 +1,109 @@
+package uk.gov.ida.matchingserviceadapter.validator;
+
+import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.opensaml.saml.saml2.core.AudienceRestriction;
+import org.opensaml.saml.saml2.core.Conditions;
+import org.opensaml.saml.saml2.core.OneTimeUse;
+import org.opensaml.saml.saml2.core.ProxyRestriction;
+import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
+import uk.gov.ida.matchingserviceadapter.validators.AssertionTimeRestrictionValidator;
+import uk.gov.ida.matchingserviceadapter.validators.AudienceRestrictionValidator;
+import uk.gov.ida.matchingserviceadapter.validators.EidasConditionsValidator;
+import uk.gov.ida.saml.core.IdaSamlBootstrap;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AudienceRestrictionBuilder.anAudienceRestriction;
+
+public class EidasConditionsValidatorTest {
+
+    private AssertionTimeRestrictionValidator timeRestrictionValidator;
+    private AudienceRestrictionValidator audienceRestrictionValidator;
+    private Conditions conditions;
+
+    private EidasConditionsValidator validator;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        timeRestrictionValidator = mock(AssertionTimeRestrictionValidator.class);
+        audienceRestrictionValidator = mock(AudienceRestrictionValidator.class);
+        conditions = mock(Conditions.class);
+
+        validator = new EidasConditionsValidator(timeRestrictionValidator, audienceRestrictionValidator);
+
+        IdaSamlBootstrap.bootstrap();
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenConditionsIsNull() {
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage("Conditions is missing from the assertion.");
+
+        validator.validate(null, "any-entity-id");
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenProxyRestrictionElementExists() {
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage("Conditions should not contain proxy restriction element.");
+
+        when(conditions.getProxyRestriction()).thenReturn(mock(ProxyRestriction.class));
+
+        validator.validate(conditions, "any-entity-id");
+    }
+
+    @Test
+    public void shouldNotThrowExceptionWhenOneTimeUseElementExists() {
+        when(conditions.getOneTimeUse()).thenReturn(mock(OneTimeUse.class));
+        validator.validate(conditions, "any-entity-id");
+    }
+
+    @Test
+    public void shouldValidateNotOnOrAfterIfExists() {
+        DateTime notOnOrAfter = new DateTime();
+        when(conditions.getNotOnOrAfter()).thenReturn(notOnOrAfter);
+
+        validator.validate(conditions, "any-entity-id");
+
+        verify(timeRestrictionValidator).validateNotOnOrAfter(notOnOrAfter);
+    }
+
+    @Test
+    public void shouldNotValidateNotOnOrAfterIfExists() {
+        DateTime notOnOrAfter = null;
+        when(conditions.getNotOnOrAfter()).thenReturn(notOnOrAfter);
+
+        validator.validate(conditions, "any-entity-id");
+    }
+
+    @Test
+    public void shouldValidateConditionsNotBefore() {
+        DateTime notBefore = new DateTime();
+        when(conditions.getNotBefore()).thenReturn(notBefore);
+
+        validator.validate(conditions, "any-entity-id");
+
+        verify(timeRestrictionValidator).validateNotBefore(notBefore);
+    }
+
+    @Test
+    public void shouldValidateConditionsAudienceRestrictions() {
+        List<AudienceRestriction> audienceRestrictions = ImmutableList.of(anAudienceRestriction().build());
+        when(conditions.getAudienceRestrictions()).thenReturn(audienceRestrictions);
+
+        validator.validate(conditions, "some-entity-id");
+
+        verify(audienceRestrictionValidator).validate(audienceRestrictions, "some-entity-id");
+    }
+}

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validator/ValidationRules/ValidationRulesTests.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validator/ValidationRules/ValidationRulesTests.java
@@ -1,0 +1,68 @@
+package uk.gov.ida.matchingserviceadapter.validator.ValidationRules;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.opensaml.saml.saml2.core.Conditions;
+import org.opensaml.saml.saml2.core.OneTimeUse;
+import org.opensaml.saml.saml2.core.ProxyRestriction;
+import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
+import uk.gov.ida.matchingserviceadapter.validators.ValidationRules.ConditionsElementMustNotBeNull;
+import uk.gov.ida.matchingserviceadapter.validators.ValidationRules.ConditionsShouldNotContainOneTimeUseElement;
+import uk.gov.ida.matchingserviceadapter.validators.ValidationRules.ConditionsShouldNotContainProxyRestrictionElement;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ValidationRulesTests {
+    Conditions conditions;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        conditions = mock(Conditions.class);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenConditionsElementIsNull() {
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage("Conditions is missing from the assertion.");
+        ConditionsElementMustNotBeNull.validate(null);
+    }
+
+    @Test
+    public void ConditionsElementMustNotBeNullWillNotThrowExceptionWhenItIsNotNull() {
+        ConditionsElementMustNotBeNull.validate(conditions);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenConditionsContainOneTimeUseElement() {
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage("Conditions should not contain one time use element.");
+        when(conditions.getOneTimeUse()).thenReturn(mock(OneTimeUse.class));
+
+        ConditionsShouldNotContainOneTimeUseElement.validate(conditions.getOneTimeUse());
+    }
+
+    @Test
+    public void shouldNotThrowExceptionWhenConditionsDoNotContainOneTimeUseElement() {
+        ConditionsShouldNotContainOneTimeUseElement.validate(conditions.getOneTimeUse());
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenConditionsContainProxyRestrictionElement() {
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage("Conditions should not contain proxy restriction element.");
+        when(conditions.getProxyRestriction()).thenReturn(mock(ProxyRestriction.class));
+
+        ConditionsShouldNotContainProxyRestrictionElement.validate(conditions.getProxyRestriction());
+    }
+
+    @Test
+    public void shouldNotThrowExceptionWhenConditionsDoNotContainProxyRestrictionElement() {
+        ConditionsShouldNotContainProxyRestrictionElement.validate(conditions.getProxyRestriction());
+    }
+}

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/validator/VerifyConditionsValidatorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/validator/VerifyConditionsValidatorTest.java
@@ -12,7 +12,7 @@ import org.opensaml.saml.saml2.core.OneTimeUse;
 import org.opensaml.saml.saml2.core.ProxyRestriction;
 import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
 import uk.gov.ida.matchingserviceadapter.validators.AudienceRestrictionValidator;
-import uk.gov.ida.matchingserviceadapter.validators.ConditionsValidator;
+import uk.gov.ida.matchingserviceadapter.validators.VerifyConditionsValidator;
 import uk.gov.ida.matchingserviceadapter.validators.AssertionTimeRestrictionValidator;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 
@@ -21,13 +21,13 @@ import java.util.List;
 import static org.mockito.Mockito.*;
 import static uk.gov.ida.saml.core.test.builders.AudienceRestrictionBuilder.anAudienceRestriction;
 
-public class ConditionsValidatorTest {
+public class VerifyConditionsValidatorTest {
 
     private AssertionTimeRestrictionValidator timeRestrictionValidator;
     private AudienceRestrictionValidator audienceRestrictionValidator;
     private Conditions conditions;
 
-    private ConditionsValidator validator;
+    private VerifyConditionsValidator validator;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -38,7 +38,7 @@ public class ConditionsValidatorTest {
         audienceRestrictionValidator = mock(AudienceRestrictionValidator.class);
         conditions = mock(Conditions.class);
 
-        validator = new ConditionsValidator(timeRestrictionValidator, audienceRestrictionValidator);
+        validator = new VerifyConditionsValidator(timeRestrictionValidator, audienceRestrictionValidator);
 
         IdaSamlBootstrap.bootstrap();
     }


### PR DESCRIPTION
An eIDAS assertion may or may not contain a OneTimeUse element.  At the point of validation in the MSA there's only one accessor for OneTimeUse in the ConditionsElement which returns a single element so there's either one there or there isn't.  An IDP should not send a OneTimeUse element.

Rename ConditionsValidator EidasConditionsValidator, copy EidasConditionsValidator and name it VerifyConditionsValidator. Create an Interface ConditionsValidator which defines the validate method used by the ConditionsValidators and have the EidasConditionsValidator and the VerifyConditionsValidator implement the interface.

Modify AssertionService, EidasAssertionService and VerifyAssertionService to take the appropriate type of ConditionsValidator.

Remove validation for OneTimeUseElement from EidasConditionsValidator.

Implement an abstract class which can be extended to implement validation rules.  Implement duplicated validation rules as classes and use in VerifyConditionsValidator and EidasConditionsValidator.