### PR TITLE
BAU: Remove healthcheck HTTP header

### DIFF
--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/MatchingResponseGenerator.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/MatchingResponseGenerator.java
@@ -62,7 +62,6 @@ public class MatchingResponseGenerator {
                     matchingServiceAdapterConfiguration.shouldSignWithSHA1());
 
         return ok()
-                .header("ida-msa-version", manifestVersionNumber)
                 .entity(soapMessageManager.wrapWithSoapEnvelope(
                                 healthCheckResponseTransformer.apply(healthCheckResponseFromMatchingService)))
                 .build();

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/MatchingResponseGeneratorTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/MatchingResponseGeneratorTest.java
@@ -68,9 +68,7 @@ public class MatchingResponseGeneratorTest {
 
         ArgumentCaptor<HealthCheckResponseFromMatchingService> healthCheckCaptor = ArgumentCaptor.forClass(HealthCheckResponseFromMatchingService.class);
         when(healthCheckResponseTransformer.apply(healthCheckCaptor.capture())).thenReturn(responseValue);
-        Response response = matchingResponseGenerator.generateHealthCheckResponse("requestId");
-
-        assertThat(response.getHeaders().getFirst("ida-msa-version")).isEqualTo("VERSION");
+        matchingResponseGenerator.generateHealthCheckResponse("requestId");
 
         String expectedRequestIdPhrase = "-version-VERSION-eidasenabled-true-shouldsignwithsha1-true";
         assertThat(healthCheckCaptor.getValue().getId()).endsWith(expectedRequestIdPhrase);


### PR DESCRIPTION
The version information returned in a custom http header is now redundant. It has been removed.