### PR TITLE
EID-1504 Allow unsigned eIDAS assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ def dependencyVersions = [
         ida_test_utils: '44',
         dev_pki: '1.1.0-34',
         trust_anchor: '1.0-34',
-        saml_libs_version: "$opensaml-192"
+        saml_libs_version: "$opensaml-193"
 ]
 
 repositories {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
@@ -87,7 +87,7 @@ public class EidasAssertionService extends AssertionService {
             .map(SamlMessageSignatureValidator::new)
             .map(SamlAssertionsSignatureValidator::new)
             .orElseThrow(() -> new SamlResponseValidationException("Unable to find metadata resolver for entity Id " + assertion.getIssuer().getValue()))
-            .validate(singletonList(assertion), IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+            .validateEidas(singletonList(assertion), IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
         instantValidator.validate(assertion.getIssueInstant(), "Country Assertion IssueInstant");
         subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
         conditionsValidator.validate(assertion.getConditions(), hubConnectorEntityId);


### PR DESCRIPTION
The eIDAS SAML profile allows for assertions to be unsigned. The verify
profile does not. Build 193 of saml-libs will allow unsigned assertions
only from eIDAS countries.