### PR TITLE
N7edPMiO: Improve MSA Logging

### DIFF
--- a/src/integration-test/java/uk/gov/ida/integrationtest/VerifyMatchingIntegrationTest.java
+++ b/src/integration-test/java/uk/gov/ida/integrationtest/VerifyMatchingIntegrationTest.java
@@ -264,6 +264,7 @@ public class VerifyMatchingIntegrationTest {
     public void shouldReturnErrorResponseWhenLocalMatchingServiceRespondsWithError() throws Exception {
         localMatchingService.reset();
         localMatchingService.register(MATCHING_REQUEST_PATH, 500, "application/json", "foo");
+
         AttributeQuery attributeQuery = AttributeQueryBuilder.anAttributeQuery()
                 .withId(REQUEST_ID)
                 .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
@@ -277,6 +278,7 @@ public class VerifyMatchingIntegrationTest {
                 .post(Entity.entity(attributeQueryDocument, TEXT_XML_TYPE));
 
         assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.readEntity(String.class)).startsWith("uk.gov.ida.matchingserviceadapter.exceptions.LocalMatchingServiceException");
     }
 
     @Test

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/ExceptionExceptionMapper.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/ExceptionExceptionMapper.java
@@ -31,6 +31,12 @@ public class ExceptionExceptionMapper implements ExceptionMapper<Exception> {
         StringBuilder sb = new StringBuilder();
         sb.append(exception.getClass().getName());
 
+        if (exception.getCause() != null) {
+            sb.append(" - Cause: ").append(exception.getCause().getClass().getName());
+        } else {
+            sb.append("No cause specified.");
+        }
+
         if (configuration.getReturnStackTraceInResponse()) {
             sb.append(" : ");
             sb.append(exception.getMessage());

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/LocalMatchingServiceException.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/LocalMatchingServiceException.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.matchingserviceadapter.exceptions;
+
+public class LocalMatchingServiceException extends RuntimeException {
+    public LocalMatchingServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/resources/MatchingServiceResource.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/resources/MatchingServiceResource.java
@@ -11,6 +11,7 @@ import org.w3c.dom.Element;
 import uk.gov.ida.matchingserviceadapter.domain.AssertionData;
 import uk.gov.ida.matchingserviceadapter.domain.EncryptedAssertionContainer;
 import uk.gov.ida.matchingserviceadapter.domain.OutboundResponseFromMatchingService;
+import uk.gov.ida.matchingserviceadapter.exceptions.LocalMatchingServiceException;
 import uk.gov.ida.matchingserviceadapter.exceptions.SamlResponseValidationException;
 import uk.gov.ida.matchingserviceadapter.logging.MdcHelper;
 import uk.gov.ida.matchingserviceadapter.mappers.MatchingServiceRequestDtoMapper;
@@ -99,9 +100,15 @@ public class MatchingServiceResource {
                 attributeQuery.getID(),
                 attributeQueryService.hashPid(assertionData),
                 assertionData);
-        MatchingServiceResponseDto matchingServiceResponse = matchingServiceProxy.makeMatchingServiceRequest(matchingServiceRequest);
-        LOG.info("Result from matching service for id " + attributeQuery.getID() + " is " + matchingServiceResponse.getResult());
 
+        MatchingServiceResponseDto matchingServiceResponse;
+        try {
+            matchingServiceResponse = matchingServiceProxy.makeMatchingServiceRequest(matchingServiceRequest);
+        } catch(Exception ex) {
+            throw new LocalMatchingServiceException("Error calling local matching service: " + ex.getMessage(), ex);
+        }
+
+        LOG.info("Result from matching service for id " + attributeQuery.getID() + " is " + matchingServiceResponse.getResult());
         OutboundResponseFromMatchingService outboundResponseFromMatchingService = matchingServiceResponseDtoToOutboundResponseFromMatchingServiceMapper.map(matchingServiceResponse,
                 matchingServiceRequest.getHashedPid(),
                 attributeQuery.getID(),

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/exceptions/ExceptionExceptionMapperTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/exceptions/ExceptionExceptionMapperTest.java
@@ -34,7 +34,7 @@ public class ExceptionExceptionMapperTest {
         Response response = exceptionExceptionMapper.toResponse(unauditedException);
 
         String responseBody = (String) response.getEntity();
-        assertThat(responseBody).contains("uk.gov.ida.exceptions.ApplicationException");
+        assertThat(responseBody).contains("uk.gov.ida.exceptions.ApplicationException - Cause: java.lang.Exception");
         assertThat(responseBody).doesNotContain(causeMessage);
     }
 
@@ -48,7 +48,7 @@ public class ExceptionExceptionMapperTest {
         Response response = exceptionExceptionMapper.toResponse(unauditedException);
 
         String responseBody = (String) response.getEntity();
-        assertThat(responseBody).contains("uk.gov.ida.exceptions.ApplicationException");
+        assertThat(responseBody).contains("uk.gov.ida.exceptions.ApplicationException - Cause: java.lang.Exception");
         assertThat(responseBody).contains(causeMessage);
     }
 }


### PR DESCRIPTION
## What

MSA logs don't contain a lot of useful information. It's hard to use them to identify what a problem is.

We should implement error logging changes to the MSA so that the full stacktrace is returned to the Verify Hub when an HTTP 500 error happens in the MSA.

There is some further background in Anshul's [investigation into MSA 500 errors](https://docs.google.com/document/d/10-oAqzKiPXu4nzwD9GL7knABwKxOLNY4oUlo6gC4uRA/edit#).

Original Zendesk ticket:
https://govuk.zendesk.com/agent/tickets/3651026

## How
Add new LocalMatchingService exception to wrap exceptions thrown while communicating with the LMS.
This will allow us to determine if MSA errors being thrown are internal MSA or being thrown by LMS.