### PR TITLE
N7edPMiO: Improve MSA Logging

### DIFF
--- a/configuration/example-lms-msa.yml
+++ b/configuration/example-lms-msa.yml
@@ -56,4 +56,4 @@ encryptionKeys:
       type: encoded
       key: ${ENCRYPTION_KEY}
 
-returnStackTraceInResponse: true
+returnStackTraceInErrorResponse: true

--- a/configuration/local/msa.yml
+++ b/configuration/local/msa.yml
@@ -59,7 +59,7 @@ encryptionKeys:
     privateKey:
       keyFile: /data/pki/sample_rp_msa_encryption_primary.pk8
 
-returnStackTraceInResponse: true
+returnStackTraceInErrorResponse: true
 
 europeanIdentity:
   enabled: ${EUROPEAN_IDENTITY_ENABLED}

--- a/configuration/test-rp-msa.yml
+++ b/configuration/test-rp-msa.yml
@@ -105,7 +105,7 @@ encryptionKeys:
     privateKey:
       keyFile: ${TEST_RP_MSA_PRIVATE_ENCRYPTION_KEY}
 
-returnStackTraceInResponse: true
+returnStackTraceInErrorResponse: true
 
 europeanIdentity:
   enabled: ${EUROPEAN_IDENTITY_ENABLED}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
@@ -28,7 +28,7 @@ public class MatchingServiceAdapterConfiguration extends Configuration implement
     @NotNull
     @Valid
     @JsonProperty
-    private Boolean returnStackTraceInResponse = false;
+    private Boolean returnStackTraceInErrorResponse = true;
 
     @NotNull
     @Valid
@@ -106,8 +106,8 @@ public class MatchingServiceAdapterConfiguration extends Configuration implement
         return matchingServiceAdapter.getExternalUrl();
     }
 
-    public boolean getReturnStackTraceInResponse() {
-        return returnStackTraceInResponse;
+    public boolean getReturnStackTraceInErrorResponse() {
+        return returnStackTraceInErrorResponse;
     }
 
     public ServiceInfo getServiceInfo() {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/ExceptionExceptionMapper.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/exceptions/ExceptionExceptionMapper.java
@@ -31,7 +31,7 @@ public class ExceptionExceptionMapper implements ExceptionMapper<Exception> {
         StringBuilder sb = new StringBuilder();
         sb.append(exception.getClass().getName());
 
-        if (configuration.getReturnStackTraceInResponse()) {
+        if (configuration.getReturnStackTraceInErrorResponse()) {
             sb.append(" : ");
             sb.append(exception.getMessage());
             sb.append("\n");

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/exceptions/ExceptionExceptionMapperTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/exceptions/ExceptionExceptionMapperTest.java
@@ -27,6 +27,7 @@ public class ExceptionExceptionMapperTest {
 
     @Test
     public void shouldNotRespondWithTheBodyOfTheUpstreamError() {
+        when(configuration.getReturnStackTraceInErrorResponse()).thenReturn(false);
         ExceptionExceptionMapper exceptionExceptionMapper = new ExceptionExceptionMapper(configuration);
 
         String causeMessage = "my message";
@@ -40,7 +41,7 @@ public class ExceptionExceptionMapperTest {
 
     @Test
     public void shouldRespondWithTheBodyOfTheUpstreamErrorWhenReturningCauseStackTrace() {
-        when(configuration.getReturnStackTraceInResponse()).thenReturn(true);
+        when(configuration.getReturnStackTraceInErrorResponse()).thenReturn(true);
         ExceptionExceptionMapper exceptionExceptionMapper = new ExceptionExceptionMapper(configuration);
 
         String causeMessage = "my message";


### PR DESCRIPTION
## What

MSA logs don't contain a lot of useful information. It's hard to use them to identify what a problem is.

We should implement error logging changes to the MSA so that the full stacktrace is returned to the Verify Hub when an HTTP 500 error happens in the MSA.

There is some further background in Anshul's [investigation into MSA 500 errors](https://docs.google.com/document/d/10-oAqzKiPXu4nzwD9GL7knABwKxOLNY4oUlo6gC4uRA/edit#).

Original Zendesk ticket:
https://govuk.zendesk.com/agent/tickets/3651026

## How

Rename flag `returnStackTraceInResponse` and set default to `true`

This will ensure that all MSAs will return stack trace to us unless we
explicitly ask them to set the renamed flag to `false` in config.