### PR TITLE
rp7KfRqL: Write MSA release notes for changes made by data team in Q1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,15 @@ MSA Release Notes
 
 ### Next
 
+* Added additional detail and stack trace to error responses. This is enabled by default but can be
+disabled by setting `returnStackTraceInErrorResponse: false` in configuration file.
+* If multiple firstnames are provided by IDP, the MSA will select which to pass to local matching service based
+in the following order:
+    1. the verified current firstname
+    1. if no verified firstname, then the first current is selected
+    1. if no verified or current then the first provided by IDP
+* When calling user account creation, if multiple current values exist for any attribute, the first verified value will be preferred over non-verified values.
+
 ### 3.1.0
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/3.0.2...3.1.0)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,11 +5,11 @@ MSA Release Notes
 
 * Added additional detail and stack trace to error responses. This is enabled by default but can be
 disabled by setting `returnStackTraceInErrorResponse: false` in configuration file.
-* If multiple firstnames are provided by IDP, the MSA will select which to pass to local matching service based
-in the following order:
+* If multiple firstnames are provided by IDP, the MSA will select which one to pass to local matching service based
+on the following rules:
     1. the verified current firstname
     1. if no verified firstname, then the first current is selected
-    1. if no verified or current then the first provided by IDP
+    1. if no verified or current then the first provided by the IDP
 * When calling user account creation, if multiple current values exist for any attribute, the first verified value will be preferred over non-verified values.
 * Removed redundant header `ida-msa-version` from matching response.
 * Upgraded `verify-saml-libs` to build 192

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,10 @@ in the following order:
     1. if no verified firstname, then the first current is selected
     1. if no verified or current then the first provided by IDP
 * When calling user account creation, if multiple current values exist for any attribute, the first verified value will be preferred over non-verified values.
+* Removed redundant header `ida-msa-version` from matching response.
+* Upgraded `verify-saml-libs` to build 192
+* Upgraded Jackson databind libs to 2.9.7 to address security vulnerabilities.
+* Upgraded OpenSAML to 3.4.0
 
 ### 3.1.0
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/3.0.2...3.1.0)


### PR DESCRIPTION
## What

We're going to do a joint release of the MSA with the `Make Verify work for users` team (eIDAS).

We've made a couple of changes to the MSA which will go out in this release. We need to: 

+ write release notes for our changes
+ check if anything else has been merged since the last release (except for eIDAS's changes) and write notes for that

## How

Added release note for extra logging (https://github.com/alphagov/verify-matching-service-adapter/pull/122)
Added release note for multiple firstname filtering (https://github.com/alphagov/verify-matching-service-adapter/pull/110)
Added release note for filter of multiple attribute values to UAC (https://github.com/alphagov/verify-matching-service-adapter/pull/113)
Added additional notes for other PRs merged since last release 
(excepting eIDAS related changes).