### PR TITLE
BAU Build with Trusty on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 env:
   global:


### PR DESCRIPTION
Travis seem to be having issues installing oraclejdk8 on Xenial, which this is currently built on (somehow). There some [chat about it here.](https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038)

See here for an example of the issue: https://travis-ci.org/alphagov/verify-matching-service-adapter/jobs/547723703

See here for an example of oraclejdk8 being installed on Trusty: https://travis-ci.org/alphagov/verify-saml-libs/jobs/547765923

Dropping to Trusty should resolve this.