### PR TITLE
EID-1583 Revert eIDAS unsigned assertions handling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,10 @@ MSA Release Notes
 
 ### Next
 
+* Revert changes to allow unsigned eIDAS assertions. An issue was identified and a new approach will be released in a future version.
+* Upgraded `verify-saml-libs` to build 209
+* Upgraded `opensaml` to version 3.4.3
+
 ### 4.0.1
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/4.0.0...4.0.1)
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ jacocoTestReport {
 }
 
 ext {
-    opensaml = '3.4.2'
+    opensaml = '3.4.3'
     build_number="$version"
 }
 
@@ -44,7 +44,7 @@ def dependencyVersions = [
         ida_utils: '370',
         ida_test_utils: '44',
         dev_pki: '1.1.0-34',
-        saml_libs_version: "$opensaml-206"
+        saml_libs_version: "$opensaml-209"
 ]
 
 repositories {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
@@ -87,7 +87,7 @@ public class EidasAssertionService extends AssertionService {
             .map(SamlMessageSignatureValidator::new)
             .map(SamlAssertionsSignatureValidator::new)
             .orElseThrow(() -> new SamlResponseValidationException("Unable to find metadata resolver for entity Id " + assertion.getIssuer().getValue()))
-            .validateEidas(singletonList(assertion), IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+            .validate(singletonList(assertion), IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
         instantValidator.validate(assertion.getIssueInstant(), "Country Assertion IssueInstant");
         subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
         conditionsValidator.validate(assertion.getConditions(), hubConnectorEntityId);


### PR DESCRIPTION
There was an issue found with the approach used to handle unsigned
assertions. This reverts that work by reverting the code and pulling in
an updated version of saml-libs that does not include the issue.