### PR TITLE
BAU Update test tools publish.gradle

### DIFF
--- a/verify-matching-service-test-tool/publish.gradle
+++ b/verify-matching-service-test-tool/publish.gradle
@@ -9,7 +9,7 @@ publishing {
             version "$build_number"
             groupId = "uk.gov.verify"
 
-            artifact file('../build/distributions/verify-matching-service-test-tool-' + "$build_number" + '.zip')
+            artifact file('build/distributions/verify-matching-service-test-tool-' + "$build_number" + '.zip')
         }
     }
     repositories {


### PR DESCRIPTION
The Jenkins build has started to fail after some changes to the gradle
files. The test-tool publication task is looking in the wrong place for
the dist. This should fix that.