### PR TITLE
EID-1683 audience validation: move from arrays to lists

### DIFF
--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
@@ -11,6 +11,7 @@ import uk.gov.ida.matchingserviceadapter.configuration.EuropeanIdentityConfigura
 import uk.gov.ida.matchingserviceadapter.configuration.HubConfiguration;
 import uk.gov.ida.matchingserviceadapter.configuration.KeyPairConfiguration;
 import uk.gov.ida.matchingserviceadapter.configuration.LocalMatchingServiceConfiguration;
+import uk.gov.ida.matchingserviceadapter.configuration.MatchingServiceAdapterEnvironment;
 import uk.gov.ida.matchingserviceadapter.configuration.MatchingServiceAdapterMetadataConfiguration;
 import uk.gov.ida.matchingserviceadapter.configuration.ServiceInfo;
 import uk.gov.ida.matchingserviceadapter.configuration.SigningKeysConfiguration;
@@ -172,5 +173,11 @@ public class MatchingServiceAdapterConfiguration extends Configuration implement
 
     public boolean isEidasEnabled() {
         return getEuropeanIdentity() != null && getEuropeanIdentity().isEnabled();
+    }
+
+    public MatchingServiceAdapterEnvironment getMetadataEnvironment() {
+        return getMetadataConfiguration().isPresent()
+            ? ((MatchingServiceAdapterMetadataConfiguration)getMetadataConfiguration().get()).getEnvironment()
+            : MatchingServiceAdapterEnvironment.INTEGRATION;
     }
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
@@ -176,8 +176,9 @@ public class MatchingServiceAdapterConfiguration extends Configuration implement
     }
 
     public MatchingServiceAdapterEnvironment getMetadataEnvironment() {
-        return getMetadataConfiguration().isPresent()
-            ? ((MatchingServiceAdapterMetadataConfiguration)getMetadataConfiguration().get()).getEnvironment()
-            : MatchingServiceAdapterEnvironment.INTEGRATION;
+        return getMetadataConfiguration()
+            .map(c -> (MatchingServiceAdapterMetadataConfiguration)c)
+            .map(MatchingServiceAdapterMetadataConfiguration::getEnvironment)
+            .orElse(MatchingServiceAdapterEnvironment.INTEGRATION);
     }
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -306,7 +306,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
     @Singleton
     @Named("AcceptableHubConnectorEntityIds")
     public List<String> getAcceptableHubConnectorEntityIds(MatchingServiceAdapterConfiguration configuration) {
-        return configuration.isEidasEnabled() ? configuration.getEuropeanIdentity().getAcceptableHubConnectorEntityIds() : new LinkedList<>();
+        return configuration.isEidasEnabled() ? configuration.getEuropeanIdentity().getAcceptableHubConnectorEntityIds(configuration.getMetadataEnvironment()) : new LinkedList<>();
     }
 
     @Provides

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -103,6 +103,7 @@ import java.io.PrintWriter;
 import java.security.KeyPair;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Timer;
@@ -251,7 +252,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
             Cycle3DatasetFactory cycle3DatasetFactory,
             MetadataResolverRepository eidasMetadataRepository,
             EidasMatchingDatasetUnmarshaller matchingDatasetUnmarshaller,
-            @Named("AcceptableHubConnectorEntityIds") String[] hubConnectorEntityIds,
+            @Named("AcceptableHubConnectorEntityIds") List<String> acceptableHubConnectorEntityIds,
             @Named("HubEntityId") String hubEntityId
     ) {
         return new EidasAssertionService(instantValidator,
@@ -260,7 +261,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
                 hubSignatureValidator,
                 cycle3DatasetFactory,
                 eidasMetadataRepository,
-                hubConnectorEntityIds,
+                acceptableHubConnectorEntityIds,
                 hubEntityId,
                 matchingDatasetUnmarshaller);
     }
@@ -304,8 +305,8 @@ class MatchingServiceAdapterModule extends AbstractModule {
     @Provides
     @Singleton
     @Named("AcceptableHubConnectorEntityIds")
-    public String[] getAcceptableHubConnectorEntityIds(MatchingServiceAdapterConfiguration configuration) {
-        return configuration.isEidasEnabled() ? configuration.getEuropeanIdentity().getAcceptableHubConnectorEntityIds() : new String[0];
+    public List<String> getAcceptableHubConnectorEntityIds(MatchingServiceAdapterConfiguration configuration) {
+        return configuration.isEidasEnabled() ? configuration.getEuropeanIdentity().getAcceptableHubConnectorEntityIds() : new LinkedList<>();
     }
 
     @Provides

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -101,9 +101,9 @@ import javax.security.cert.X509Certificate;
 import javax.ws.rs.client.Client;
 import java.io.PrintWriter;
 import java.security.KeyPair;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Timer;
@@ -306,7 +306,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
     @Singleton
     @Named("AcceptableHubConnectorEntityIds")
     public List<String> getAcceptableHubConnectorEntityIds(MatchingServiceAdapterConfiguration configuration) {
-        return configuration.isEidasEnabled() ? configuration.getEuropeanIdentity().getAcceptableHubConnectorEntityIds(configuration.getMetadataEnvironment()) : new LinkedList<>();
+        return configuration.isEidasEnabled() ? configuration.getEuropeanIdentity().getAcceptableHubConnectorEntityIds(configuration.getMetadataEnvironment()) : new ArrayList<>();
     }
 
     @Provides

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationConstants.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationConstants.java
@@ -1,0 +1,34 @@
+package uk.gov.ida.matchingserviceadapter.configuration;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.jetty.util.TypeUtil.asList;
+
+public class EuropeanConfigurationConstants {
+
+    private static String[] ACCEPTABLE_HUB_CONNECTOR_IDS_PRODUCTION = new String[] {
+        "https://www.signin.service.gov.uk/SAML2/metadata/connector",               // (AWS)
+        "https://connector-node.london.verify.govsvc.uk/SAML2/ConnectorMetadata",   // (GSP)
+        "https://eidas.signin.service.gov.uk/ConnectorMetadata",                    // (potential new #1)
+        "https://connector.eidas.signin.service.gov.uk/ConnectorMetadata",          // (potential new #2)
+        "https://connector-node.eidas.signin.service.gov.uk/ConnectorMetadata",     // (potential new #3)
+    };
+
+    private static String[] ACCEPTABLE_HUB_CONNECTOR_IDS_INTEGRATION = new String[]{
+        // TODO
+    };
+
+    private static Map<MatchingServiceAdapterEnvironment, List<String>> defaultAcceptableHubConnectorIds;
+
+    public static Map<MatchingServiceAdapterEnvironment, List<String>> getDefaultAcceptableHubConnectorIds() {
+        if (defaultAcceptableHubConnectorIds == null) {
+            defaultAcceptableHubConnectorIds = new HashMap<>();
+            defaultAcceptableHubConnectorIds.put(MatchingServiceAdapterEnvironment.INTEGRATION, asList(ACCEPTABLE_HUB_CONNECTOR_IDS_INTEGRATION));
+            defaultAcceptableHubConnectorIds.put(MatchingServiceAdapterEnvironment.PRODUCTION, asList(ACCEPTABLE_HUB_CONNECTOR_IDS_PRODUCTION));
+        }
+        return defaultAcceptableHubConnectorIds;
+    }
+
+}

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationConstants.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationConstants.java
@@ -8,7 +8,7 @@ import static org.eclipse.jetty.util.TypeUtil.asList;
 
 public class EuropeanConfigurationConstants {
 
-    private static String[] ACCEPTABLE_HUB_CONNECTOR_IDS_PRODUCTION = new String[] {
+    private static final String[] ACCEPTABLE_HUB_CONNECTOR_IDS_PRODUCTION = new String[] {
         "https://www.signin.service.gov.uk/SAML2/metadata/connector",               // (AWS)
         "https://connector-node.london.verify.govsvc.uk/SAML2/ConnectorMetadata",   // (GSP)
         "https://eidas.signin.service.gov.uk/ConnectorMetadata",                    // (potential new #1)
@@ -16,19 +16,16 @@ public class EuropeanConfigurationConstants {
         "https://connector-node.eidas.signin.service.gov.uk/ConnectorMetadata",     // (potential new #3)
     };
 
-    private static String[] ACCEPTABLE_HUB_CONNECTOR_IDS_INTEGRATION = new String[]{
+    private static final String[] ACCEPTABLE_HUB_CONNECTOR_IDS_INTEGRATION = new String[]{
         // TODO
     };
 
-    private static Map<MatchingServiceAdapterEnvironment, List<String>> defaultAcceptableHubConnectorIds;
+    public static Map<MatchingServiceAdapterEnvironment, List<String>> DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS;
 
-    public static Map<MatchingServiceAdapterEnvironment, List<String>> getDefaultAcceptableHubConnectorIds() {
-        if (defaultAcceptableHubConnectorIds == null) {
-            defaultAcceptableHubConnectorIds = new HashMap<>();
-            defaultAcceptableHubConnectorIds.put(MatchingServiceAdapterEnvironment.INTEGRATION, asList(ACCEPTABLE_HUB_CONNECTOR_IDS_INTEGRATION));
-            defaultAcceptableHubConnectorIds.put(MatchingServiceAdapterEnvironment.PRODUCTION, asList(ACCEPTABLE_HUB_CONNECTOR_IDS_PRODUCTION));
-        }
-        return defaultAcceptableHubConnectorIds;
+    static {
+        DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS = new HashMap<>();
+        DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS.put(MatchingServiceAdapterEnvironment.INTEGRATION, asList(ACCEPTABLE_HUB_CONNECTOR_IDS_INTEGRATION));
+        DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS.put(MatchingServiceAdapterEnvironment.PRODUCTION, asList(ACCEPTABLE_HUB_CONNECTOR_IDS_PRODUCTION));
     }
 
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationDefaultsHelper.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationDefaultsHelper.java
@@ -8,24 +8,24 @@ import static org.eclipse.jetty.util.TypeUtil.asList;
 
 public class EuropeanConfigurationDefaultsHelper {
 
-    private static final String[] ACCEPTABLE_HUB_CONNECTOR_IDS_PRODUCTION = new String[] {
+    private static final String[] ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS_PRODUCTION = new String[] {
         "https://www.signin.service.gov.uk/SAML2/metadata/connector",               // (AWS)
-        "https://connector-node.london.verify.govsvc.uk/SAML2/ConnectorMetadata",   // (GSP)
+        "https://connector-node.london.verify.govsvc.uk/ConnectorMetadata",         // (GSP)
         "https://eidas.signin.service.gov.uk/ConnectorMetadata",                    // (potential new #1)
         "https://connector.eidas.signin.service.gov.uk/ConnectorMetadata",          // (potential new #2)
         "https://connector-node.eidas.signin.service.gov.uk/ConnectorMetadata",     // (potential new #3)
     };
 
-    private static final String[] ACCEPTABLE_HUB_CONNECTOR_IDS_INTEGRATION = new String[]{
+    private static final String[] ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS_INTEGRATION = new String[]{
         // TODO
     };
 
-    public static Map<MatchingServiceAdapterEnvironment, List<String>> DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS;
+    public static Map<MatchingServiceAdapterEnvironment, List<String>> DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS;
 
     static {
-        DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS = new HashMap<>();
-        DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS.put(MatchingServiceAdapterEnvironment.INTEGRATION, asList(ACCEPTABLE_HUB_CONNECTOR_IDS_INTEGRATION));
-        DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS.put(MatchingServiceAdapterEnvironment.PRODUCTION, asList(ACCEPTABLE_HUB_CONNECTOR_IDS_PRODUCTION));
+        DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS = new HashMap<>();
+        DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS.put(MatchingServiceAdapterEnvironment.INTEGRATION, asList(ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS_INTEGRATION));
+        DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS.put(MatchingServiceAdapterEnvironment.PRODUCTION, asList(ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS_PRODUCTION));
     }
 
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationDefaultsHelper.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationDefaultsHelper.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import static org.eclipse.jetty.util.TypeUtil.asList;
 
-public class EuropeanConfigurationConstants {
+public class EuropeanConfigurationDefaultsHelper {
 
     private static final String[] ACCEPTABLE_HUB_CONNECTOR_IDS_PRODUCTION = new String[] {
         "https://www.signin.service.gov.uk/SAML2/metadata/connector",               // (AWS)

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationDefaultsHelper.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationDefaultsHelper.java
@@ -17,7 +17,11 @@ public class EuropeanConfigurationDefaultsHelper {
     };
 
     private static final String[] ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS_INTEGRATION = new String[]{
-        // TODO
+        "https://www.integration.signin.service.gov.uk/SAML2/metadata/connector",               // (AWS)
+        "https://connector-node-integration.london.verify.govsvc.uk/ConnectorMetadata",         // (GSP)
+        "https://integration.eidas.signin.service.gov.uk/ConnectorMetadata",                    // (potential new #1)
+        "https://connector.integration.eidas.signin.service.gov.uk/ConnectorMetadata",          // (potential new #2)
+        "https://connector-node.integration.eidas.signin.service.gov.uk/ConnectorMetadata",     // (potential new #3)
     };
 
     public static Map<MatchingServiceAdapterEnvironment, List<String>> DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS;

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static uk.gov.ida.matchingserviceadapter.configuration.EuropeanConfigurationConstants.getDefaultAcceptableHubConnectorIds;
+import static uk.gov.ida.matchingserviceadapter.configuration.EuropeanConfigurationConstants.DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS;
 
 public class EuropeanIdentityConfiguration {
 
@@ -38,7 +38,7 @@ public class EuropeanIdentityConfiguration {
     }
 
     public List<String> getAcceptableHubConnectorEntityIds(MatchingServiceAdapterEnvironment environment) {
-        Set<String> entityIds = new HashSet<>(getDefaultAcceptableHubConnectorIds().getOrDefault(environment, new ArrayList<>()));
+        Set<String> entityIds = new HashSet<>(DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS.getOrDefault(environment, new ArrayList<>()));
         Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);
         Optional.ofNullable(hubConnectorEntityId).ifPresent(entityIds::add);
         return new ArrayList<>(entityIds);

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
@@ -5,6 +5,11 @@ import uk.gov.ida.saml.metadata.EidasMetadataConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 public class EuropeanIdentityConfiguration {
 
@@ -15,7 +20,7 @@ public class EuropeanIdentityConfiguration {
 
     @Valid
     @JsonProperty
-    private String[] acceptableHubConnectorEntityIds;
+    private List<String> acceptableHubConnectorEntityIds;
 
     @NotNull
     @Valid
@@ -30,10 +35,11 @@ public class EuropeanIdentityConfiguration {
         return hubConnectorEntityId;
     }
 
-    public String[] getAcceptableHubConnectorEntityIds() {
-        return acceptableHubConnectorEntityIds != null && acceptableHubConnectorEntityIds.length > 0
-            ? acceptableHubConnectorEntityIds
-            : new String[] { hubConnectorEntityId };
+    public List<String> getAcceptableHubConnectorEntityIds() {
+        Set<String> entityIds = new LinkedHashSet<>();
+        Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);
+        Optional.ofNullable(hubConnectorEntityId).ifPresent(entityIds::add);
+        return new LinkedList<>(entityIds);
     }
 
     public EidasMetadataConfiguration getAggregatedMetadata() {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static uk.gov.ida.matchingserviceadapter.configuration.EuropeanConfigurationConstants.DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS;
+import static uk.gov.ida.matchingserviceadapter.configuration.EuropeanConfigurationDefaultsHelper.DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS;
 
 public class EuropeanIdentityConfiguration {
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static uk.gov.ida.matchingserviceadapter.configuration.EuropeanConfigurationDefaultsHelper.DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS;
+import static uk.gov.ida.matchingserviceadapter.configuration.EuropeanConfigurationDefaultsHelper.DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS;
 
 public class EuropeanIdentityConfiguration {
 
@@ -38,7 +38,7 @@ public class EuropeanIdentityConfiguration {
     }
 
     public List<String> getAcceptableHubConnectorEntityIds(MatchingServiceAdapterEnvironment environment) {
-        Set<String> entityIds = new HashSet<>(DEFAULT_ACCEPTABLE_HUB_CONNECTOR_IDS.getOrDefault(environment, new ArrayList<>()));
+        Set<String> entityIds = new HashSet<>(DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS.getOrDefault(environment, new ArrayList<>()));
         Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);
         Optional.ofNullable(hubConnectorEntityId).ifPresent(entityIds::add);
         return new ArrayList<>(entityIds);

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
@@ -5,11 +5,13 @@ import uk.gov.ida.saml.metadata.EidasMetadataConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
+import static uk.gov.ida.matchingserviceadapter.configuration.EuropeanConfigurationConstants.getDefaultAcceptableHubConnectorIds;
 
 public class EuropeanIdentityConfiguration {
 
@@ -35,11 +37,11 @@ public class EuropeanIdentityConfiguration {
         return hubConnectorEntityId;
     }
 
-    public List<String> getAcceptableHubConnectorEntityIds() {
-        Set<String> entityIds = new LinkedHashSet<>();
+    public List<String> getAcceptableHubConnectorEntityIds(MatchingServiceAdapterEnvironment environment) {
+        Set<String> entityIds = new HashSet<>(getDefaultAcceptableHubConnectorIds().getOrDefault(environment, new ArrayList<>()));
         Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);
         Optional.ofNullable(hubConnectorEntityId).ifPresent(entityIds::add);
-        return new LinkedList<>(entityIds);
+        return new ArrayList<>(entityIds);
     }
 
     public EidasMetadataConfiguration getAggregatedMetadata() {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/MatchingServiceAdapterMetadataConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/MatchingServiceAdapterMetadataConfiguration.java
@@ -51,6 +51,10 @@ public class MatchingServiceAdapterMetadataConfiguration extends TrustStoreBacke
         this.environment = Optional.ofNullable(environment).orElse(MatchingServiceAdapterEnvironment.INTEGRATION);
     }
 
+    public MatchingServiceAdapterEnvironment getEnvironment() {
+        return environment;
+    }
+
     @Override
     public Optional<KeyStore> getHubTrustStore() {
         return Optional.of(

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
@@ -27,7 +27,7 @@ public class EidasAssertionService extends AssertionService {
 
     private final CountryConditionsValidator conditionsValidator;
     private final MetadataResolverRepository metadataResolverRepository;
-    private final String[] acceptableHubConnectorEntityIds;
+    private final List<String> acceptableHubConnectorEntityIds;
     private final String hubEntityId;
     private final EidasMatchingDatasetUnmarshaller matchingDatasetUnmarshaller;
     private final AuthnContextFactory authnContextFactory = new AuthnContextFactory();
@@ -39,7 +39,7 @@ public class EidasAssertionService extends AssertionService {
                                  SamlAssertionsSignatureValidator hubSignatureValidator,
                                  Cycle3DatasetFactory cycle3DatasetFactory,
                                  MetadataResolverRepository metadataResolverRepository,
-                                 @Named("AcceptableHubConnectorEntityIds") String[] acceptableHubConnectorEntityIds,
+                                 @Named("AcceptableHubConnectorEntityIds") List<String> acceptableHubConnectorEntityIds,
                                  String hubEntityId,
                                  EidasMatchingDatasetUnmarshaller matchingDatasetUnmarshaller) {
         super(instantValidator, subjectValidator, conditionsValidator, hubSignatureValidator, cycle3DatasetFactory);
@@ -91,7 +91,7 @@ public class EidasAssertionService extends AssertionService {
             .validate(singletonList(assertion), IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
         instantValidator.validate(assertion.getIssueInstant(), "Country Assertion IssueInstant");
         subjectValidator.validate(assertion.getSubject(), expectedInResponseTo);
-        conditionsValidator.validate(assertion.getConditions(), acceptableHubConnectorEntityIds);
+        conditionsValidator.validate(assertion.getConditions(), acceptableHubConnectorEntityIds.toArray(new String[0]));
     }
 
     public Boolean isCountryAssertion(Assertion assertion) {

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionServiceTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionServiceTest.java
@@ -19,7 +19,7 @@ import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
 import uk.gov.ida.saml.security.validators.ValidatedAssertions;
 import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -68,7 +68,7 @@ public class EidasAssertionServiceTest {
                 hubSignatureValidator,
                 new Cycle3DatasetFactory(),
                 metadataResolverRepository,
-                new String[] { HUB_CONNECTOR_ENTITY_ID },
+                Collections.singletonList(HUB_CONNECTOR_ENTITY_ID),
                 HUB_ENTITY_ID,
                 new EidasMatchingDatasetUnmarshaller()
         );
@@ -76,7 +76,7 @@ public class EidasAssertionServiceTest {
         doNothing().when(subjectValidator).validate(any(), any());
         doNothing().when(conditionsValidator).validate(any(), any());
         when(hubSignatureValidator.validate(any(), any())).thenReturn(mock(ValidatedAssertions.class));
-        when(metadataResolverRepository.getResolverEntityIds()).thenReturn(Arrays.asList(STUB_COUNTRY_ONE));
+        when(metadataResolverRepository.getResolverEntityIds()).thenReturn(Collections.singletonList(STUB_COUNTRY_ONE));
 
         DateTimeFreezer.freezeTime();
     }


### PR DESCRIPTION
A quick update to manage `acceptableHubConnectedEntityIds` as a List rather than an array.

See feedback from: https://github.com/alphagov/verify-matching-service-adapter/pull/140