### PR TITLE
EID-1683 make hubConnectorEntityId optional

### DIFF
--- a/src/integration-test/java/uk/gov/ida/integrationtest/interfacetests/EidasExampleSchemaTests.java
+++ b/src/integration-test/java/uk/gov/ida/integrationtest/interfacetests/EidasExampleSchemaTests.java
@@ -69,7 +69,7 @@ public class EidasExampleSchemaTests extends BaseTestToolInterfaceTest {
                     .withConditions(
                         aConditions()
                         .validFor(Duration.standardMinutes(10))
-                        .restrictedToAudience(appRule.getConfiguration().getEuropeanIdentity().getHubConnectorEntityId(INTEGRATION))
+                        .restrictedToAudience(appRule.getConfiguration().getEuropeanIdentity().getAllAcceptableHubConnectorEntityIds(INTEGRATION).stream().findFirst().get())
                         .build())
                     .withIssuer(anIssuer().withIssuerId(appRule.getCountryEntityId()).build())
                     .withSignature(anEidasSignature())
@@ -100,7 +100,7 @@ public class EidasExampleSchemaTests extends BaseTestToolInterfaceTest {
                     .withConditions(
                         aConditions()
                         .validFor(Duration.standardMinutes(10))
-                        .restrictedToAudience(appRule.getConfiguration().getEuropeanIdentity().getHubConnectorEntityId(INTEGRATION))
+                        .restrictedToAudience(appRule.getConfiguration().getEuropeanIdentity().getAllAcceptableHubConnectorEntityIds(INTEGRATION).stream().findFirst().get())
                         .build())
                     .withIssuer(anIssuer().withIssuerId(appRule.getCountryEntityId()).build())
                     .withSignature(aSignature().withSigningCredential(COUNTRY_SIGNING_CREDENTIAL).build())
@@ -131,7 +131,7 @@ public class EidasExampleSchemaTests extends BaseTestToolInterfaceTest {
                     .withConditions(
                         aConditions()
                         .validFor(Duration.standardMinutes(10))
-                        .restrictedToAudience(appRule.getConfiguration().getEuropeanIdentity().getHubConnectorEntityId(INTEGRATION))
+                        .restrictedToAudience(appRule.getConfiguration().getEuropeanIdentity().getAllAcceptableHubConnectorEntityIds(INTEGRATION).stream().findFirst().get())
                         .build())
                     .withIssuer(anIssuer().withIssuerId(appRule.getCountryEntityId()).build())
                     .withSignature(aSignature().withSigningCredential(COUNTRY_SIGNING_CREDENTIAL).build())

--- a/src/integration-test/java/uk/gov/ida/integrationtest/interfacetests/EidasExampleSchemaTests.java
+++ b/src/integration-test/java/uk/gov/ida/integrationtest/interfacetests/EidasExampleSchemaTests.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.integrationtest.interfacetests;
 
+import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.joda.time.Duration;
 import org.joda.time.LocalDate;
 import org.junit.ClassRule;
@@ -7,8 +8,6 @@ import org.junit.Test;
 import org.opensaml.saml.saml2.core.AttributeQuery;
 import org.opensaml.saml.saml2.core.Subject;
 import org.opensaml.security.credential.Credential;
-
-import io.dropwizard.testing.junit.DropwizardAppRule;
 import uk.gov.ida.integrationtest.helpers.MatchingServiceAdapterAppRule;
 import uk.gov.ida.matchingserviceadapter.MatchingServiceAdapterConfiguration;
 import uk.gov.ida.saml.core.test.builders.AttributeQueryBuilder;
@@ -20,10 +19,11 @@ import java.nio.file.Paths;
 import static java.util.Arrays.asList;
 import static uk.gov.ida.integrationtest.helpers.AssertionHelper.aSubjectWithEncryptedAssertions;
 import static uk.gov.ida.integrationtest.helpers.AssertionHelper.anEidasSignature;
-import static uk.gov.ida.matchingserviceadapter.builders.AttributeStatementBuilder.aCurrentGivenNameAttribute;
 import static uk.gov.ida.matchingserviceadapter.builders.AttributeStatementBuilder.aCurrentFamilyNameAttribute;
+import static uk.gov.ida.matchingserviceadapter.builders.AttributeStatementBuilder.aCurrentGivenNameAttribute;
 import static uk.gov.ida.matchingserviceadapter.builders.AttributeStatementBuilder.aDateOfBirthAttribute;
 import static uk.gov.ida.matchingserviceadapter.builders.AttributeStatementBuilder.aPersonIdentifierAttribute;
+import static uk.gov.ida.matchingserviceadapter.configuration.MatchingServiceAdapterEnvironment.INTEGRATION;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_PRIVATE_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PUBLIC_ENCRYPTION_CERT;
@@ -69,7 +69,7 @@ public class EidasExampleSchemaTests extends BaseTestToolInterfaceTest {
                     .withConditions(
                         aConditions()
                         .validFor(Duration.standardMinutes(10))
-                        .restrictedToAudience(appRule.getConfiguration().getEuropeanIdentity().getHubConnectorEntityId())
+                        .restrictedToAudience(appRule.getConfiguration().getEuropeanIdentity().getHubConnectorEntityId(INTEGRATION))
                         .build())
                     .withIssuer(anIssuer().withIssuerId(appRule.getCountryEntityId()).build())
                     .withSignature(anEidasSignature())
@@ -100,7 +100,7 @@ public class EidasExampleSchemaTests extends BaseTestToolInterfaceTest {
                     .withConditions(
                         aConditions()
                         .validFor(Duration.standardMinutes(10))
-                        .restrictedToAudience(appRule.getConfiguration().getEuropeanIdentity().getHubConnectorEntityId())
+                        .restrictedToAudience(appRule.getConfiguration().getEuropeanIdentity().getHubConnectorEntityId(INTEGRATION))
                         .build())
                     .withIssuer(anIssuer().withIssuerId(appRule.getCountryEntityId()).build())
                     .withSignature(aSignature().withSigningCredential(COUNTRY_SIGNING_CREDENTIAL).build())
@@ -131,7 +131,7 @@ public class EidasExampleSchemaTests extends BaseTestToolInterfaceTest {
                     .withConditions(
                         aConditions()
                         .validFor(Duration.standardMinutes(10))
-                        .restrictedToAudience(appRule.getConfiguration().getEuropeanIdentity().getHubConnectorEntityId())
+                        .restrictedToAudience(appRule.getConfiguration().getEuropeanIdentity().getHubConnectorEntityId(INTEGRATION))
                         .build())
                     .withIssuer(anIssuer().withIssuerId(appRule.getCountryEntityId()).build())
                     .withSignature(aSignature().withSigningCredential(COUNTRY_SIGNING_CREDENTIAL).build())

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterConfiguration.java
@@ -177,7 +177,7 @@ public class MatchingServiceAdapterConfiguration extends Configuration implement
 
     public MatchingServiceAdapterEnvironment getMetadataEnvironment() {
         return getMetadataConfiguration()
-            .map(c -> (MatchingServiceAdapterMetadataConfiguration)c)
+            .map(config -> (MatchingServiceAdapterMetadataConfiguration)config)
             .map(MatchingServiceAdapterMetadataConfiguration::getEnvironment)
             .orElse(MatchingServiceAdapterEnvironment.INTEGRATION);
     }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -252,7 +252,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
             Cycle3DatasetFactory cycle3DatasetFactory,
             MetadataResolverRepository eidasMetadataRepository,
             EidasMatchingDatasetUnmarshaller matchingDatasetUnmarshaller,
-            @Named("AcceptableHubConnectorEntityIds") List<String> acceptableHubConnectorEntityIds,
+            @Named("AllAcceptableHubConnectorEntityIds") List<String> acceptableHubConnectorEntityIds,
             @Named("HubEntityId") String hubEntityId
     ) {
         return new EidasAssertionService(instantValidator,
@@ -297,16 +297,9 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    @Named("HubConnectorEntityId")
-    public String getHubConnectorEntityId(MatchingServiceAdapterConfiguration configuration) {
-        return configuration.isEidasEnabled() ? configuration.getEuropeanIdentity().getHubConnectorEntityId(configuration.getMetadataEnvironment()) : "";
-    }
-
-    @Provides
-    @Singleton
-    @Named("AcceptableHubConnectorEntityIds")
+    @Named("AllAcceptableHubConnectorEntityIds")
     public List<String> getAcceptableHubConnectorEntityIds(MatchingServiceAdapterConfiguration configuration) {
-        return configuration.isEidasEnabled() ? configuration.getEuropeanIdentity().getAcceptableHubConnectorEntityIds(configuration.getMetadataEnvironment()) : new ArrayList<>();
+        return configuration.isEidasEnabled() ? configuration.getEuropeanIdentity().getAllAcceptableHubConnectorEntityIds(configuration.getMetadataEnvironment()) : new ArrayList<>();
     }
 
     @Provides

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -299,7 +299,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
     @Singleton
     @Named("HubConnectorEntityId")
     public String getHubConnectorEntityId(MatchingServiceAdapterConfiguration configuration) {
-        return configuration.isEidasEnabled() ? configuration.getEuropeanIdentity().getHubConnectorEntityId() : "";
+        return configuration.isEidasEnabled() ? configuration.getEuropeanIdentity().getHubConnectorEntityId(configuration.getMetadataEnvironment()) : "";
     }
 
     @Provides

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationDefaultsHelper.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationDefaultsHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.matchingserviceadapter.configuration;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,12 +25,15 @@ public class EuropeanConfigurationDefaultsHelper {
         "https://connector-node.eidas.integration.signin.service.gov.uk/ConnectorMetadata",     // (potential new #3)
     };
 
-    public static Map<MatchingServiceAdapterEnvironment, List<String>> DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS;
-
-    static {
-        DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS = new HashMap<>();
-        DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS.put(MatchingServiceAdapterEnvironment.INTEGRATION, asList(ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS_INTEGRATION));
-        DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS.put(MatchingServiceAdapterEnvironment.PRODUCTION, asList(ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS_PRODUCTION));
+    public static List<String> getDefaultAcceptableHubConnectorEntityIds(MatchingServiceAdapterEnvironment environment) {
+        switch (environment) {
+            case INTEGRATION:
+                return asList(ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS_INTEGRATION);
+            case PRODUCTION:
+                return asList(ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS_PRODUCTION);
+            default:
+                throw new IllegalArgumentException(environment.name());
+        }
     }
 
 }

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationDefaultsHelper.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanConfigurationDefaultsHelper.java
@@ -19,9 +19,9 @@ public class EuropeanConfigurationDefaultsHelper {
     private static final String[] ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS_INTEGRATION = new String[]{
         "https://www.integration.signin.service.gov.uk/SAML2/metadata/connector",               // (AWS)
         "https://connector-node-integration.london.verify.govsvc.uk/ConnectorMetadata",         // (GSP)
-        "https://integration.eidas.signin.service.gov.uk/ConnectorMetadata",                    // (potential new #1)
-        "https://connector.integration.eidas.signin.service.gov.uk/ConnectorMetadata",          // (potential new #2)
-        "https://connector-node.integration.eidas.signin.service.gov.uk/ConnectorMetadata",     // (potential new #3)
+        "https://eidas.integration.signin.service.gov.uk/ConnectorMetadata",                    // (potential new #1)
+        "https://connector.eidas.integration.signin.service.gov.uk/ConnectorMetadata",          // (potential new #2)
+        "https://connector-node.eidas.integration.signin.service.gov.uk/ConnectorMetadata",     // (potential new #3)
     };
 
     public static Map<MatchingServiceAdapterEnvironment, List<String>> DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS;

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
@@ -15,7 +15,6 @@ import static uk.gov.ida.matchingserviceadapter.configuration.EuropeanConfigurat
 
 public class EuropeanIdentityConfiguration {
 
-    @NotNull
     @Valid
     @JsonProperty
     private String hubConnectorEntityId;
@@ -33,8 +32,8 @@ public class EuropeanIdentityConfiguration {
     @JsonProperty
     private EidasMetadataConfiguration aggregatedMetadata;
 
-    public String getHubConnectorEntityId() {
-        return hubConnectorEntityId;
+    public String getHubConnectorEntityId(MatchingServiceAdapterEnvironment environment) {
+        return Optional.ofNullable(hubConnectorEntityId).orElse(getAcceptableHubConnectorEntityIds(environment).stream().findFirst().orElse(null));
     }
 
     public List<String> getAcceptableHubConnectorEntityIds(MatchingServiceAdapterEnvironment environment) {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static uk.gov.ida.matchingserviceadapter.configuration.EuropeanConfigurationDefaultsHelper.DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS;
+import static uk.gov.ida.matchingserviceadapter.configuration.EuropeanConfigurationDefaultsHelper.getDefaultAcceptableHubConnectorEntityIds;
 
 public class EuropeanIdentityConfiguration {
 
@@ -33,7 +33,7 @@ public class EuropeanIdentityConfiguration {
     private EidasMetadataConfiguration aggregatedMetadata;
 
     public List<String> getAllAcceptableHubConnectorEntityIds(MatchingServiceAdapterEnvironment environment) {
-        Set<String> entityIds = new HashSet<>(DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS.getOrDefault(environment, new ArrayList<>()));
+        Set<String> entityIds = new HashSet<>(getDefaultAcceptableHubConnectorEntityIds(environment));
         Optional.ofNullable(hubConnectorEntityId).ifPresent(entityIds::add);
         Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);
         return new ArrayList<>(entityIds);

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
@@ -38,8 +38,8 @@ public class EuropeanIdentityConfiguration {
 
     public List<String> getAcceptableHubConnectorEntityIds(MatchingServiceAdapterEnvironment environment) {
         Set<String> entityIds = new HashSet<>(DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS.getOrDefault(environment, new ArrayList<>()));
-        Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);
         Optional.ofNullable(hubConnectorEntityId).ifPresent(entityIds::add);
+        Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);
         return new ArrayList<>(entityIds);
     }
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/configuration/EuropeanIdentityConfiguration.java
@@ -32,11 +32,7 @@ public class EuropeanIdentityConfiguration {
     @JsonProperty
     private EidasMetadataConfiguration aggregatedMetadata;
 
-    public String getHubConnectorEntityId(MatchingServiceAdapterEnvironment environment) {
-        return Optional.ofNullable(hubConnectorEntityId).orElse(getAcceptableHubConnectorEntityIds(environment).stream().findFirst().orElse(null));
-    }
-
-    public List<String> getAcceptableHubConnectorEntityIds(MatchingServiceAdapterEnvironment environment) {
+    public List<String> getAllAcceptableHubConnectorEntityIds(MatchingServiceAdapterEnvironment environment) {
         Set<String> entityIds = new HashSet<>(DEFAULT_ACCEPTABLE_HUB_CONNECTOR_ENTITY_IDS.getOrDefault(environment, new ArrayList<>()));
         Optional.ofNullable(hubConnectorEntityId).ifPresent(entityIds::add);
         Optional.ofNullable(acceptableHubConnectorEntityIds).ifPresent(entityIds::addAll);

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionService.java
@@ -39,7 +39,7 @@ public class EidasAssertionService extends AssertionService {
                                  SamlAssertionsSignatureValidator hubSignatureValidator,
                                  Cycle3DatasetFactory cycle3DatasetFactory,
                                  MetadataResolverRepository metadataResolverRepository,
-                                 @Named("AcceptableHubConnectorEntityIds") List<String> acceptableHubConnectorEntityIds,
+                                 @Named("AllAcceptableHubConnectorEntityIds") List<String> acceptableHubConnectorEntityIds,
                                  String hubEntityId,
                                  EidasMatchingDatasetUnmarshaller matchingDatasetUnmarshaller) {
         super(instantValidator, subjectValidator, conditionsValidator, hubSignatureValidator, cycle3DatasetFactory);


### PR DESCRIPTION
This change:

- ... makes the `hubConnectorEntityId` configuration option nullable.
- ... defers to the first `acceptableHubConnectorEntityId` if the `hubConnectorEntityId` is not provided.
- ... updates the subdomains inside the potential new entity ids themselves.