### PR TITLE
Decrypt and unmarshall eidas unsigned assertions in MSA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ def dependencyVersions = [
         ida_utils: '370',
         ida_test_utils: '44',
         dev_pki: '1.1.0-34',
-        saml_libs_version: "$opensaml-221"
+        saml_libs_version: "$opensaml-222"
 ]
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ def dependencyVersions = [
         ida_utils: '370',
         ida_test_utils: '44',
         dev_pki: '1.1.0-34',
-        saml_libs_version: "$opensaml-219"
+        saml_libs_version: "$opensaml-221"
 ]
 
 repositories {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -71,6 +71,9 @@ import uk.gov.ida.saml.core.transformers.inbound.Cycle3DatasetFactory;
 import uk.gov.ida.saml.core.validation.conditions.AudienceRestrictionValidator;
 import uk.gov.ida.saml.deserializers.ElementToOpenSamlXMLObjectTransformer;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.deserializers.validators.ResponseSizeValidator;
+import uk.gov.ida.saml.deserializers.validators.SizeValidator;
+import uk.gov.ida.saml.hub.validators.StringSizeValidator;
 import uk.gov.ida.saml.metadata.DisabledMetadataResolverRepository;
 import uk.gov.ida.saml.metadata.EidasMetadataConfiguration;
 import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
@@ -184,7 +187,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
     @Provides
     @Singleton
     public EidasUnsignedMatchingDatasetUnmarshaller getEidasUnsignedMatchingDatasetUnmarshaller(SecretKeyDecryptorFactory secretKeyDecryptorFactory) {
-        StringToOpenSamlObjectTransformer<Response> stringtoOpenSamlObjectTransformer = new CoreTransformersFactory().getStringtoOpenSamlObjectTransformer(input -> {});
+        StringToOpenSamlObjectTransformer<Response> stringtoOpenSamlObjectTransformer = new CoreTransformersFactory().getStringtoOpenSamlObjectTransformer(new ResponseSizeValidator());
         return new EidasUnsignedMatchingDatasetUnmarshaller(secretKeyDecryptorFactory, stringtoOpenSamlObjectTransformer);
     }
 

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -11,6 +11,7 @@ import org.joda.time.Duration;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver;
 import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.encryption.Decrypter;
 import org.opensaml.saml.saml2.metadata.EntitiesDescriptor;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
@@ -64,10 +65,12 @@ import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import uk.gov.ida.saml.core.api.CoreTransformersFactory;
 import uk.gov.ida.saml.core.domain.AddressFactory;
 import uk.gov.ida.saml.core.transformers.EidasMatchingDatasetUnmarshaller;
+import uk.gov.ida.saml.core.transformers.EidasUnsignedMatchingDatasetUnmarshaller;
 import uk.gov.ida.saml.core.transformers.VerifyMatchingDatasetUnmarshaller;
 import uk.gov.ida.saml.core.transformers.inbound.Cycle3DatasetFactory;
 import uk.gov.ida.saml.core.validation.conditions.AudienceRestrictionValidator;
 import uk.gov.ida.saml.deserializers.ElementToOpenSamlXMLObjectTransformer;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.metadata.DisabledMetadataResolverRepository;
 import uk.gov.ida.saml.metadata.EidasMetadataConfiguration;
 import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
@@ -89,6 +92,8 @@ import uk.gov.ida.saml.security.MetadataBackedEncryptionCredentialResolver;
 import uk.gov.ida.saml.security.MetadataBackedSignatureValidator;
 import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
 import uk.gov.ida.saml.security.SamlMessageSignatureValidator;
+import uk.gov.ida.saml.security.SecretKeyDecryptorFactory;
+import uk.gov.ida.saml.security.SecretKeyEncrypter;
 import uk.gov.ida.saml.security.validators.encryptedelementtype.EncryptionAlgorithmValidator;
 import uk.gov.ida.shared.utils.manifest.ManifestReader;
 import uk.gov.ida.truststore.KeyStoreLoader;
@@ -178,6 +183,19 @@ class MatchingServiceAdapterModule extends AbstractModule {
 
     @Provides
     @Singleton
+    public EidasUnsignedMatchingDatasetUnmarshaller getEidasUnsignedMatchingDatasetUnmarshaller(SecretKeyDecryptorFactory secretKeyDecryptorFactory) {
+        StringToOpenSamlObjectTransformer<Response> stringtoOpenSamlObjectTransformer = new CoreTransformersFactory().getStringtoOpenSamlObjectTransformer(input -> {});
+        return new EidasUnsignedMatchingDatasetUnmarshaller(secretKeyDecryptorFactory, stringtoOpenSamlObjectTransformer);
+    }
+
+    @Provides
+    @Singleton
+    public SecretKeyDecryptorFactory getSecretKeyDecryptorFactory(IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever) {
+        return new SecretKeyDecryptorFactory(idaKeyStoreCredentialRetriever);
+    }
+
+    @Provides
+    @Singleton
     public VerifyMatchingDatasetUnmarshaller getVerifyMatchingDatasetUnmarshaller(AddressFactory addressFactory) {
         return new VerifyMatchingDatasetUnmarshaller(addressFactory);
     }
@@ -252,6 +270,7 @@ class MatchingServiceAdapterModule extends AbstractModule {
             Cycle3DatasetFactory cycle3DatasetFactory,
             MetadataResolverRepository eidasMetadataRepository,
             EidasMatchingDatasetUnmarshaller matchingDatasetUnmarshaller,
+            EidasUnsignedMatchingDatasetUnmarshaller matchingUnsignedDatasetUnmarshaller,
             @Named("AllAcceptableHubConnectorEntityIds") List<String> acceptableHubConnectorEntityIds,
             @Named("HubEntityId") String hubEntityId
     ) {
@@ -263,7 +282,8 @@ class MatchingServiceAdapterModule extends AbstractModule {
                 eidasMetadataRepository,
                 acceptableHubConnectorEntityIds,
                 hubEntityId,
-                matchingDatasetUnmarshaller);
+                matchingDatasetUnmarshaller,
+                matchingUnsignedDatasetUnmarshaller);
     }
 
     @Provides
@@ -510,6 +530,12 @@ class MatchingServiceAdapterModule extends AbstractModule {
         registerMetadataRefreshTask(environment, ofNullable(resolverRepository), Collections.unmodifiableCollection(resolverRepository.getMetadataResolvers().values()), "eidas-metadata");
         environment.healthChecks().register("TrustAnchorHealthCheck", new EidasTrustAnchorHealthCheck(resolverRepository));
         return resolverRepository;
+    }
+
+    @Provides
+    @Singleton
+    private SecretKeyEncrypter getSecretKeyEncrypter(MetadataBackedEncryptionCredentialResolver encryptionCredentialResolver) {
+        return new SecretKeyEncrypter(encryptionCredentialResolver);
     }
 
     public static void registerMetadataRefreshTask(Environment environment, Optional<EidasMetadataResolverRepository> eidasMetadataResolverRepository, Collection<MetadataResolver> metadataResolvers, String name) {

--- a/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
+++ b/src/main/java/uk/gov/ida/matchingserviceadapter/MatchingServiceAdapterModule.java
@@ -72,8 +72,6 @@ import uk.gov.ida.saml.core.validation.conditions.AudienceRestrictionValidator;
 import uk.gov.ida.saml.deserializers.ElementToOpenSamlXMLObjectTransformer;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.deserializers.validators.ResponseSizeValidator;
-import uk.gov.ida.saml.deserializers.validators.SizeValidator;
-import uk.gov.ida.saml.hub.validators.StringSizeValidator;
 import uk.gov.ida.saml.metadata.DisabledMetadataResolverRepository;
 import uk.gov.ida.saml.metadata.EidasMetadataConfiguration;
 import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionServiceTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionServiceTest.java
@@ -33,6 +33,7 @@ import uk.gov.ida.saml.security.SigningCredentialFactory;
 import uk.gov.ida.saml.security.validators.ValidatedAssertions;
 import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -148,7 +149,7 @@ public class EidasAssertionServiceTest {
                         new AttributeStatementBuilder()
                                 .addAttribute(unsignedAssertions).build())
                 .buildUnencrypted();
-        eidasAssertionService.validate("bob", List.of(eidasUnisgnedAssertion));
+        eidasAssertionService.validate("bob", Arrays.asList(eidasUnisgnedAssertion));
         verify(metadataResolverRepository, never()).getSignatureTrustEngine(any(String.class));
     }
 
@@ -157,7 +158,7 @@ public class EidasAssertionServiceTest {
         ExplicitKeySignatureTrustEngine trustEngine = getExplicitKeySignatureTrustEngine();
         when(metadataResolverRepository.getSignatureTrustEngine(TestEntityIds.STUB_COUNTRY_ONE)).thenReturn(Optional.of(trustEngine));
         Assertion eidasAssertion = AttributeQueryServiceTest.anEidasAssertion("requestId", TestEntityIds.STUB_COUNTRY_ONE, anEidasSignature());
-        eidasAssertionService.validate("bob", List.of(eidasAssertion));
+        eidasAssertionService.validate("bob", Arrays.asList(eidasAssertion));
         verify(metadataResolverRepository).getSignatureTrustEngine(TestEntityIds.STUB_COUNTRY_ONE);
     }
 
@@ -166,7 +167,7 @@ public class EidasAssertionServiceTest {
         Attribute unsignedAssertions = new OpenSamlXmlObjectFactory().createAttribute();
         unsignedAssertions.setName(IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
 
-        List<Assertion> assertions = List.of(anEidasAssertion().addAttributeStatement(
+        List<Assertion> assertions = Arrays.asList(anEidasAssertion().addAttributeStatement(
                 new AttributeStatementBuilder()
                 .addAttribute(unsignedAssertions)
                         .build())
@@ -192,7 +193,7 @@ public class EidasAssertionServiceTest {
                 eidasUnsignedMatchingDatasetUnmarshaller
         );
 
-        List<Assertion> assertions = List.of(anEidasAssertion().buildUnencrypted());
+        List<Assertion> assertions = Arrays.asList(anEidasAssertion().buildUnencrypted());
         eidasAssertionService.translate(assertions);
         verify(eidasMatchingDatasetUnmarshaller).fromAssertion(any(Assertion.class));
     }

--- a/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionServiceTest.java
+++ b/src/test/java/uk/gov/ida/matchingserviceadapter/services/EidasAssertionServiceTest.java
@@ -7,30 +7,47 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.CredentialResolver;
+import org.opensaml.security.credential.impl.StaticCredentialResolver;
+import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.keyinfo.KeyInfoCredentialResolver;
+import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
 import uk.gov.ida.matchingserviceadapter.domain.AssertionData;
 import uk.gov.ida.matchingserviceadapter.validators.CountryConditionsValidator;
 import uk.gov.ida.matchingserviceadapter.validators.InstantValidator;
 import uk.gov.ida.matchingserviceadapter.validators.SubjectValidator;
+import uk.gov.ida.saml.core.IdaConstants;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
+import uk.gov.ida.saml.core.test.HardCodedKeyStore;
+import uk.gov.ida.saml.core.test.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder;
 import uk.gov.ida.saml.core.transformers.EidasMatchingDatasetUnmarshaller;
+import uk.gov.ida.saml.core.transformers.EidasUnsignedMatchingDatasetUnmarshaller;
 import uk.gov.ida.saml.core.transformers.inbound.Cycle3DatasetFactory;
 import uk.gov.ida.saml.metadata.MetadataResolverRepository;
 import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.saml.security.SigningCredentialFactory;
 import uk.gov.ida.saml.security.validators.ValidatedAssertions;
 import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static uk.gov.ida.matchingserviceadapter.services.AttributeQueryServiceTest.anEidasSignature;
 import static uk.gov.ida.saml.core.domain.AuthnContext.LEVEL_2;
 import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_CONNECTOR_ENTITY_ID;
 import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_ENTITY_ID;
@@ -57,6 +74,9 @@ public class EidasAssertionServiceTest {
     @Mock
     private MetadataResolverRepository metadataResolverRepository;
 
+    @Mock
+    private EidasUnsignedMatchingDatasetUnmarshaller eidasUnsignedMatchingDatasetUnmarshaller;
+
     @Before
     public void setUp() {
         IdaSamlBootstrap.bootstrap();
@@ -70,7 +90,8 @@ public class EidasAssertionServiceTest {
                 metadataResolverRepository,
                 Collections.singletonList(HUB_CONNECTOR_ENTITY_ID),
                 HUB_ENTITY_ID,
-                new EidasMatchingDatasetUnmarshaller()
+                new EidasMatchingDatasetUnmarshaller(),
+                eidasUnsignedMatchingDatasetUnmarshaller
         );
         doNothing().when(instantValidator).validate(any(), any());
         doNothing().when(subjectValidator).validate(any(), any());
@@ -107,7 +128,6 @@ public class EidasAssertionServiceTest {
         Assertion cycle3Assertion = aCycle3DatasetAssertion("NI", "123456").buildUnencrypted();
         List<Assertion> assertions = asList( eidasAssertion, cycle3Assertion);
         AssertionData assertionData = eidasAssertionService.translate(assertions);
-
         assertThat(assertionData.getLevelOfAssurance()).isEqualTo(LEVEL_2);
         assertThat(assertionData.getMatchingDatasetIssuer()).isEqualTo(STUB_COUNTRY_ONE);
         assertThat(assertionData.getCycle3Data().get().getAttributes().get("NI")).isEqualTo("123456");
@@ -116,4 +136,72 @@ public class EidasAssertionServiceTest {
         assertThat(assertionData.getMatchingDataset().getPersonalId()).isEqualTo("JB12345");
         assertThat(assertionData.getMatchingDataset().getDateOfBirths().get(0).getValue()).isEqualTo(LocalDate.now());
     }
+
+    @Test
+    public void shouldNotAttemptToValidateSignatureOnUnsignedAssertion() {
+        Attribute unsignedAssertions = new OpenSamlXmlObjectFactory().createAttribute();
+        unsignedAssertions.setName(IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
+
+
+        Assertion eidasUnisgnedAssertion = anEidasAssertion().withoutSigning()
+                .addAttributeStatement(
+                        new AttributeStatementBuilder()
+                                .addAttribute(unsignedAssertions).build())
+                .buildUnencrypted();
+        eidasAssertionService.validate("bob", List.of(eidasUnisgnedAssertion));
+        verify(metadataResolverRepository, never()).getSignatureTrustEngine(any(String.class));
+    }
+
+    @Test
+    public void shouldValidateSignatureOnSignedAssertion() {
+        ExplicitKeySignatureTrustEngine trustEngine = getExplicitKeySignatureTrustEngine();
+        when(metadataResolverRepository.getSignatureTrustEngine(TestEntityIds.STUB_COUNTRY_ONE)).thenReturn(Optional.of(trustEngine));
+        Assertion eidasAssertion = AttributeQueryServiceTest.anEidasAssertion("requestId", TestEntityIds.STUB_COUNTRY_ONE, anEidasSignature());
+        eidasAssertionService.validate("bob", List.of(eidasAssertion));
+        verify(metadataResolverRepository).getSignatureTrustEngine(TestEntityIds.STUB_COUNTRY_ONE);
+    }
+
+    @Test
+    public void shouldUseMatchingUnsignedDatasetUnmarshallerForUnsignedAssertions() {
+        Attribute unsignedAssertions = new OpenSamlXmlObjectFactory().createAttribute();
+        unsignedAssertions.setName(IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
+
+        List<Assertion> assertions = List.of(anEidasAssertion().addAttributeStatement(
+                new AttributeStatementBuilder()
+                .addAttribute(unsignedAssertions)
+                        .build())
+                .buildUnencrypted());
+        eidasAssertionService.translate(assertions);
+        verify(eidasUnsignedMatchingDatasetUnmarshaller).fromAssertion(any(Assertion.class));
+    }
+
+
+    @Test
+    public void shouldUseEidasMatchingDatasetUnmarshallerForSignedAssertions() {
+        EidasMatchingDatasetUnmarshaller eidasMatchingDatasetUnmarshaller = mock(EidasMatchingDatasetUnmarshaller.class);
+        eidasAssertionService = new EidasAssertionService(
+                instantValidator,
+                subjectValidator,
+                conditionsValidator,
+                hubSignatureValidator,
+                new Cycle3DatasetFactory(),
+                metadataResolverRepository,
+                Collections.singletonList(HUB_CONNECTOR_ENTITY_ID),
+                HUB_ENTITY_ID,
+                eidasMatchingDatasetUnmarshaller,
+                eidasUnsignedMatchingDatasetUnmarshaller
+        );
+
+        List<Assertion> assertions = List.of(anEidasAssertion().buildUnencrypted());
+        eidasAssertionService.translate(assertions);
+        verify(eidasMatchingDatasetUnmarshaller).fromAssertion(any(Assertion.class));
+    }
+
+    private ExplicitKeySignatureTrustEngine getExplicitKeySignatureTrustEngine() {
+        List<Credential> credentials = new SigningCredentialFactory(new HardCodedKeyStore(TestEntityIds.HUB_ENTITY_ID)).getVerifyingCredentials(TestEntityIds.STUB_COUNTRY_ONE);
+        CredentialResolver credResolver = new StaticCredentialResolver(credentials);
+        KeyInfoCredentialResolver kiResolver = DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver();
+        return new ExplicitKeySignatureTrustEngine(credResolver, kiResolver);
+    }
 }
+


### PR DESCRIPTION
When the Hub evaluates that eidas assertions are unsigned it provides:
- the entire eidas saml response to the MSA
- and an encrypted secret key, 

as attributes. This Hub work is already merged from https://github.com/alphagov/verify-hub/pull/381

the MSA uses its private encryption key to decrypt the encrypted secret key, uses that key to decrypt the assertions within the eidas saml response, and then unmarshalls the response.
The work above is done by `EidasUnsignedMatchingDatasetUnmarshaller`, and is already merged in `saml-libs`, see https://github.com/alphagov/verify-saml-libs/pull/88.

**This PR** allows the MSA to evaluate whether the attributes in the AttributeQuery contains the eidas saml response, and in this case:
 - the signature of the assertions is not checked,
- and the assertions are then sent to the `EidasUnsignedMatchingDatasetUnmarshaller` to be decrypted and unmarshalled

I've inlined some comments on specific code below to help.