### PR TITLE
EID-1698: fix release process (version number)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ ext {
 }
 
 group = "uk.gov.ida"
+project.version = "$gradle.ext.version_number-$build_number"
 
 def dependencyVersions = [
         opensaml:"$opensaml",


### PR DESCRIPTION
Version number is required in order to create correctly-named zip.