### PR TITLE
AUT-14: Make METADATA_ENTITY_ID configurable

### DIFF
--- a/ci/manifest.yml.tmpl
+++ b/ci/manifest.yml.tmpl
@@ -14,7 +14,7 @@ applications:
       TEST_RP_ROUTE: http://test-rp-$ENV.apps.internal:8080
       METADATA_URL: $METADATA_URL
       SIGNIN_DOMAIN: $SIGNIN_DOMAIN
-      METADATA_ENTITY_ID: https://signin.service.gov.uk
+      METADATA_ENTITY_ID: $METADATA_ENTITY_ID
       TRUSTSTORE_PATH: /app/msa/truststores/$TRUSTSTORE_NAME
       TRUSTSTORE_PASSWORD: $TRUSTSTORE_PASSWORD
       EUROPEAN_IDENTITY_ENABLED: true


### PR DESCRIPTION
This change replaces a hardcoded value with a variable for METADATA_ENTITY_ID. This will allow us to configure a job to set the variable to a different entity id for different environment.

Author: @adityapahuja