### PR TITLE
Add msa backward compatibility config

### DIFF
--- a/configuration/compatibility-testing/msa-backcompat-manifest.yml.tmpl
+++ b/configuration/compatibility-testing/msa-backcompat-manifest.yml.tmpl
@@ -1,0 +1,19 @@
+---
+# a templated cloud foundry manifest file for running supported MSA
+# versions in PaaS
+applications:
+  - name: test-rp-msa-backcompat-${INDEX}
+    routes:
+      - route: test-rp-msa-staging-backcompat-${INDEX}.cloudapps.digital
+      - route: test-rp-msa-staging-backcompat-${INDEX}.apps.internal
+    memory: 1G
+    buildpack: java_buildpack
+    env:
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
+      INDEX: ${INDEX}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      ENCRYPTION_CERT: ${ENCRYPTION_CERT}
+      SIGNING_KEY: ${SIGNING_KEY}
+      SIGNING_CERT: ${SIGNING_CERT}
+    services:
+      - logit-staging

--- a/configuration/compatibility-testing/test-rp-msa-3.1.0-840.yml
+++ b/configuration/compatibility-testing/test-rp-msa-3.1.0-840.yml
@@ -48,7 +48,7 @@ metadata:
     timeToLive: 10m
     connectionTimeout: 4s
     retries: 3
-    keepAlive: 60s
+    keepAlive: 10s
     chunkedEncodingEnabled: false
     validateAfterInactivityPeriod: 5s
     tls:
@@ -95,7 +95,7 @@ europeanIdentity:
       cookiesEnabled: false
       connectionTimeout: 1s
       retries: 3
-      keepAlive: 60s
+      keepAlive: 10s
       chunkedEncodingEnabled: false
       validateAfterInactivityPeriod: 5s
       tls:

--- a/configuration/compatibility-testing/test-rp-msa-3.1.0-840.yml
+++ b/configuration/compatibility-testing/test-rp-msa-3.1.0-840.yml
@@ -75,7 +75,7 @@ encryptionKeys:
       type: encoded
       key: ${ENCRYPTION_KEY}
 
-returnStackTraceInResponse: true
+returnStackTraceInErrorResponse: true
 
 europeanIdentity:
   enabled: true

--- a/configuration/compatibility-testing/test-rp-msa-3.1.0-840.yml
+++ b/configuration/compatibility-testing/test-rp-msa-3.1.0-840.yml
@@ -1,0 +1,104 @@
+# Config for MSA 3.1.0-840 deployed to staging on paas
+
+server:
+  applicationConnectors:
+    - type: http
+      port: 8080
+  adminConnectors:
+    - type: http
+      port: 8081
+
+matchingServiceAdapter:
+  entityId: http://www.test-rp-ms-${INDEX}.gov.uk/SAML2/MD
+  externalUrl: https://test-rp-msa-staging-backcompat-${INDEX}.cloudapps.digital/matching-service/POST
+
+localMatchingService:
+  matchUrl: http://test-rp-staging-backcompat-${INDEX}.apps.internal:8080/test-rp/matching-service/POST
+  accountCreationUrl: http://test-rp-staging-backcompat-${INDEX}.apps.internal:8080/test-rp/unknown-user/POST
+  client:
+    timeout: 60s
+    timeToLive: 10m
+    connectionTimeout: 4s
+    tls:
+      verifyHostname: false
+      trustSelfSignedCertificates: true
+
+hub:
+  ssoUrl: https://www.staging.signin.service.gov.uk/SAML2/SSO
+  republishHubCertificatesInLocalMetadata: true
+  hubEntityId: https://signin.service.gov.uk
+
+metadata:
+  url: https://www.staging.signin.service.gov.uk/SAML2/metadata/federation
+  trustStore:
+    path: test_ida_metadata.ts
+    password: puppet
+  environment: INTEGRATION
+  # hubTrustStore:
+  #     path: /ida/truststore/ida_hub_truststore.ts
+  #     password: puppet
+  # idpTrustStore:
+  #     path: /ida/truststore/ida_idp_truststore.ts
+  #     password: puppet
+  minRefreshDelay: 30000
+  maxRefreshDelay: 1800000
+  expectedEntityId: https://signin.service.gov.uk
+  client:
+    timeout: 60s
+    timeToLive: 10m
+    connectionTimeout: 4s
+    retries: 3
+    keepAlive: 60s
+    chunkedEncodingEnabled: false
+    validateAfterInactivityPeriod: 5s
+    tls:
+      protocol: TLSv1.2
+      verifyHostname: false
+      trustSelfSignedCertificates: true
+
+signingKeys:
+  primary:
+    publicKey:
+      type: encoded
+      cert: ${SIGNING_CERT}
+      name: http://www.test-rp-ms.gov.uk/SAML2/MD
+    privateKey:
+      type: encoded
+      key: ${SIGNING_KEY}
+
+encryptionKeys:
+  - publicKey:
+      type: encoded
+      cert: ${ENCRYPTION_CERT}
+      name: http://www.test-rp-ms.gov.uk/SAML2/MD
+    privateKey:
+      type: encoded
+      key: ${ENCRYPTION_KEY}
+
+returnStackTraceInResponse: true
+
+europeanIdentity:
+  enabled: true
+  hubConnectorEntityId: https://hub-connector-eidas-staging.cloudapps.digital/metadata.xml
+  aggregatedMetadata:
+    trustAnchorUri: https://www.staging.signin.service.gov.uk/SAML2/metadata/trust-anchor
+    metadataSourceUri: https://www.staging.signin.service.gov.uk/SAML2/metadata/aggregator
+    trustStore:
+      path: test_ida_metadata.ts
+      password: puppet
+    minRefreshDelay: 5000
+    maxRefreshDelay: 600000
+    jerseyClientName: trust-anchor-client
+    client:
+      timeout: 2s
+      timeToLive: 10m
+      cookiesEnabled: false
+      connectionTimeout: 1s
+      retries: 3
+      keepAlive: 60s
+      chunkedEncodingEnabled: false
+      validateAfterInactivityPeriod: 5s
+      tls:
+        protocol: TLSv1.2
+        verifyHostname: false
+        trustSelfSignedCertificates: true

--- a/configuration/compatibility-testing/test-rp-msa-4.1.0-884.yml
+++ b/configuration/compatibility-testing/test-rp-msa-4.1.0-884.yml
@@ -1,4 +1,4 @@
-# Config for MSA 3.1.0-840 deployed to staging on paas
+# Config for MSA 4.1.0-884 deployed to staging on paas
 
 server:
   applicationConnectors:

--- a/configuration/compatibility-testing/test-rp-msa-4.2.1-901.yml
+++ b/configuration/compatibility-testing/test-rp-msa-4.2.1-901.yml
@@ -1,4 +1,4 @@
-# Config for MSA 3.1.0-840 deployed to staging on paas
+# Config for MSA 4.2.1-901 deployed to staging on paas
 
 server:
   applicationConnectors:


### PR DESCRIPTION
This adds config files for use in deploying old supported versions of the MSA for our backward-compatibility tests.

Previously, these files lived unmanaged on the disk of jenkins, in /srv/maven.  They should probably be checked into source control instead.

The config files are all the same, but I'm keeping different files for different versions because:

 - it's how the backward-compatibility tests used to work
 - it allows us to change the config file format between MSA versions