### PR TITLE
ZD-4070599: Fixed broken link

### DIFF
--- a/USAGE_README.md
+++ b/USAGE_README.md
@@ -5,13 +5,10 @@ The Matching Service Adapter (MSA) is a software tool provided by GOV.UK
 Verify. It simplifies communication between your local matching service and the
 GOV.UK Verify hub.
 
-If you are a government service connecting to GOV.UK Verify, refer to the USAGE_README 
-for more information on [how to install and use the MSA](USAGE_README.md).
-
 It is published as a zip file that contains the jar file and all of its dependencies.
 See the [release notes](RELEASE_NOTES.md) for specific release information.
 
-For more details, see [the full documentation on how to use the MSA.](http://alphagov.github.io/rp-onboarding-tech-docs/pages/msa/msa.html)
+For more details, see [the full documentation on how to use the MSA.](https://www.docs.verify.service.gov.uk/legacy/build-ms/msa/#matching-service-adapter)
 
 Pre-requisites
 --------------


### PR DESCRIPTION
Has a link to "full documentation on how to use the MSA" pointing to http://alphagov.github.io/rp-onboarding-tech-docs/pages/msa/msa.html
This page has a redirect which takes the user to the home page of the Verify tech docs, which isn't particularly useful. The link should point to
https://www.docs.verify.service.gov.uk/legacy/build-ms/msa/#matching-service-adapter

links in matching-service-adapter will be fixed in upcoming PR in www.docs.verify.service