### PR TITLE
HUB-539: Keep Concourse MSA version in step with local version

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -24,5 +24,32 @@ run:
     - -c
     - |
       cd msa
+
+      # If the version in `settings.gradle` has been bumped, ensure the Concourse version is in step
+      local_version=$(cat settings.gradle | grep -oP " *version_number = '\K[0-9]+\.[0-9]+\.[0-9]+(?=')")
+      remote_version=$(cat ../msa-version/number)
+
+      oIFS="$IFS"
+      IFS=.
+      set -- $local_version
+      local_major=$1
+      local_minor=$2
+      local_patch=$3
+
+      set -- $remote_version
+      remote_major=$1
+      remote_minor=$2
+      remote_patch=$3
+
+      IFS="$oIFS"
+
+      if [ "$local_major" -gt "$remote_major" ]; then
+        echo "$local_major"."$local_minor"."$local_patch" > ../msa-version/number
+      elif [ "$local_minor" -gt "$remote_minor" ]; then
+        echo "$remote_major"."$local_minor"."$local_patch" > ../msa-version/number
+      elif [ "$local_patch" -gt "$remote_patch" ]; then
+        echo "$remote_major"."$remote_minor"."$local_patch" > ../msa-version/number
+      fi
+
       ./gradlew distZip -Pversion=$(cat ../msa-version/number) --no-daemon
       cp build/distributions/msa-*.zip ../msa-artifact/


### PR DESCRIPTION
The concourse build pipeline uses a semver resource to keep track of
different builds of the MSA. Every new PR that's merged triggers a build
and the pipeline bumps the patch version. This new version is used as
the version number for a draft github release.

When we want to generate a new release of the MSA for use by RP's we
bump the version in the `settings.gradle`. This will almost always
either include a major or minor bump.

This commit allows the build pipeline to pick up that change and update
the Concourse version to match. This will then produce a draft release
on Github with the correct version which we can then promote to a full
release.

See the pipeline config here for context: https://github.com/alphagov/verify-infrastructure-config/blob/master/pipelines/deployer/deploy-stubs.yml#L571