### PR TITLE
BAU: Add msa-version as a task output

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -13,6 +13,7 @@ inputs:
 
 outputs:
   - name: msa-artifact
+  - name: msa-version
 
 caches:
   - path: ../../../root/.gradle/caches


### PR DESCRIPTION
If we went to propagate the update version, it needs to be an output.