### PR TITLE
BAU: Bump patch version to re-align versions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ MSA Release Notes
 
 ### Next
 
-### 5.0.0
+### 5.0.2
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/4.2.1...5.0.0)
 * Breaking change for configuration. Default metadata trust stores are now used by default and no longer need configuring. The defaults can still be overridden. If you are not using custom trust stores you will need to remove the config to allow the defaults to work. In particular `test_ida_metadata.ts` and `prod_ida_metadata.ts` no longer exist. See below for config change details.
 * Breaking change for configuration. The `europeanIdentity.aggregatedMetadata` configuration now no longer requires values for `trustStore`, `trustAnchorUri` and `metadataSourceUri`. Default values are used instead when `europeanIdentity.aggregatedMetadata.environment` is specified as `PRODUCTION` or `INTEGRATION`. The default values can be overridden if desired. As above, `test_ida_metadata.ts` and `prod_ida_metadata.ts` no longer exist. See below for config change details.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 include 'verify-matching-service-test-tool'
 
 gradle.ext {
-    version_number = '5.0.0'
+    version_number = '5.0.2'
 }


### PR DESCRIPTION
Due to some issues with the new logic to keep the Concourse semver
version in line with the version in settings.gradle we need to bump to a
slightly later version and allow the pipeline to re-run.