### PR TITLE
HUB-697: Fix up some config

### DIFF
--- a/ci/example-lms-msa-manifest.yml
+++ b/ci/example-lms-msa-manifest.yml
@@ -13,6 +13,4 @@ applications:
       LMS_URI: http://((lms_app)).apps.internal:8080
       SIGNIN_DOMAIN: www.((hub_env)).signin.service.gov.uk
       METADATA_ENTITY_ID: https://signin.service.gov.uk
-      METADATA_TRUSTSTORE_PATH: ((truststore_path))
-      METADATA_TRUSTSTORE_PASSWORD: ((truststore_password))
       EUROPEAN_IDENTITY_ENABLED: false

--- a/configuration/compatibility-testing/test-rp-msa-5.0.2.yml
+++ b/configuration/compatibility-testing/test-rp-msa-5.0.2.yml
@@ -1,0 +1,91 @@
+# Config for MSA 5.0.2-5.0.2 deployed to staging on paas
+
+server:
+  applicationConnectors:
+    - type: http
+      port: 8080
+  adminConnectors:
+    - type: http
+      port: 8081
+
+matchingServiceAdapter:
+  entityId: http://www.test-rp-ms-${INDEX}.gov.uk/SAML2/MD
+  externalUrl: https://test-rp-msa-staging-backcompat-${INDEX}.cloudapps.digital/matching-service/POST
+
+localMatchingService:
+  matchUrl: http://test-rp-staging-backcompat-${INDEX}.apps.internal:8080/test-rp/matching-service/POST
+  accountCreationUrl: http://test-rp-staging-backcompat-${INDEX}.apps.internal:8080/test-rp/unknown-user/POST
+  client:
+    timeout: 60s
+    timeToLive: 10m
+    connectionTimeout: 4s
+    tls:
+      verifyHostname: false
+      trustSelfSignedCertificates: true
+
+hub:
+  ssoUrl: https://www.staging.signin.service.gov.uk/SAML2/SSO
+  republishHubCertificatesInLocalMetadata: true
+  hubEntityId: https://signin.service.gov.uk
+
+metadata:
+  url: https://www.staging.signin.service.gov.uk/SAML2/metadata/federation
+  environment: INTEGRATION
+  minRefreshDelay: 30000
+  maxRefreshDelay: 1800000
+  expectedEntityId: https://signin.service.gov.uk
+  client:
+    timeout: 60s
+    timeToLive: 10m
+    connectionTimeout: 4s
+    retries: 3
+    keepAlive: 10s
+    chunkedEncodingEnabled: false
+    validateAfterInactivityPeriod: 5s
+    tls:
+      protocol: TLSv1.2
+      verifyHostname: false
+      trustSelfSignedCertificates: true
+
+signingKeys:
+  primary:
+    publicKey:
+      type: encoded
+      cert: ${SIGNING_CERT}
+      name: http://www.test-rp-ms.gov.uk/SAML2/MD
+    privateKey:
+      type: encoded
+      key: ${SIGNING_KEY}
+
+encryptionKeys:
+  - publicKey:
+      type: encoded
+      cert: ${ENCRYPTION_CERT}
+      name: http://www.test-rp-ms.gov.uk/SAML2/MD
+    privateKey:
+      type: encoded
+      key: ${ENCRYPTION_KEY}
+
+returnStackTraceInErrorResponse: true
+
+europeanIdentity:
+  enabled: true
+  hubConnectorEntityId: https://hub-connector-eidas-staging.cloudapps.digital/metadata.xml
+  aggregatedMetadata:
+    environment: INTEGRATION
+    minRefreshDelay: 5000
+    maxRefreshDelay: 600000
+    jerseyClientName: trust-anchor-client
+    client:
+      timeout: 2s
+      timeToLive: 10m
+      cookiesEnabled: false
+      connectionTimeout: 1s
+      retries: 3
+      keepAlive: 10s
+      chunkedEncodingEnabled: false
+      validateAfterInactivityPeriod: 5s
+      tls:
+        protocol: TLSv1.2
+        verifyHostname: false
+        trustSelfSignedCertificates: true

--- a/configuration/compatibility-testing/test-rp-msa-5.0.2.yml
+++ b/configuration/compatibility-testing/test-rp-msa-5.0.2.yml
@@ -1,4 +1,4 @@
-# Config for MSA 5.0.2-5.0.2 deployed to staging on paas
+# Config for MSA 5.0.2 deployed to staging on paas
 
 server:
   applicationConnectors:

--- a/configuration/example-lms-msa.yml
+++ b/configuration/example-lms-msa.yml
@@ -32,9 +32,6 @@ metadata:
   environment: ${ENVIRONMENT:-INTEGRATION}
   minRefreshDelay: 30000
   maxRefreshDelay: 1800000
-  trustStore:
-    path: ${METADATA_TRUSTSTORE_PATH}
-    password: ${METADATA_TRUSTSTORE_PASSWORD}
   expectedEntityId: ${METADATA_ENTITY_ID}
 
 signingKeys:


### PR DESCRIPTION
### HUB-697: Rename config file for 5.0.2 test-rp
When the Concourse job actually deploys the test-rp, it looks for this
file based on the git tag associated with the MSA release. In this case
it's 5.0.2.

### HUB-697: Remove trust store config from LMS CI

As part of releasing the VSP we spin up an MSA: https://cd.gds-reliability.engineering/teams/verify/pipelines/verify-service-provider/jobs/deploy-msa-in-integration

This MSA is just pulled from master and uses the config that we're
changing here. That config is still looking for the old trust stores so
we need to remove it. There will also be a change to the pipeline to
stop providing the variables to the manifest.