### PR TITLE
BAU: Update example-lms-msa.yml to use encoded signing cert

### DIFF
--- a/configuration/example-lms-msa.yml
+++ b/configuration/example-lms-msa.yml
@@ -37,7 +37,7 @@ metadata:
 signingKeys:
   primary:
     publicKey:
-      type: x509
+      type: encoded
       cert: ${SIGNING_CERT}
       name: http://www.vsp-ms.gov.uk
     privateKey:


### PR DESCRIPTION
For some reason we were using an `x509` type for the cert. In 99% of
places we use encoded.

This update hopefully make it more intuitive for future people.