### PR TITLE
HUB-720 Fix the broken Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY build.gradle build.gradle
 COPY settings.gradle settings.gradle
 COPY publish.gradle publish.gradle
 
-RUN gradle install
+RUN gradle installDist
 
 COPY src/ src/
 COPY configuration/ configuration/

--- a/configuration/local/msa.yml
+++ b/configuration/local/msa.yml
@@ -65,7 +65,7 @@ europeanIdentity:
   enabled: ${EUROPEAN_IDENTITY_ENABLED}
   hubConnectorEntityId: ${HUB_CONNECTOR_ENTITY_ID}
   aggregatedMetadata:
-    trustAnchorUri: ${TRUST_ANCHOR_URL}
+    trustAnchorUri: ${TRUST_ANCHOR_URI}
     metadataSourceUri: ${METADATA_SOURCE_URI}
     trustStore:
       path: /data/pki/metadata.ts


### PR DESCRIPTION
The Dockerfile in the Matching Service adapter is actually broken.  There is no target called install.  For this reason I have updated
the Dockerfile to point to installDist which I think should be the correct gradle target.