### PR TITLE
BAU: Upgrade saml-libs to 249

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@ MSA Release Notes
 =================
 
 ### Next
+* Fixes an issue with trust anchors for eIDAS metadata resolvers not being updated when they changed at source. The MSA
+  will now update them without requiring a restart.
 
 ### 5.0.2
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/4.2.1...5.0.0)

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ def dependencyVersions = [
         ida_utils: '386',
         ida_test_utils: '44',
         dev_pki: '1.1.0-34',
-        saml_libs_version: "$opensaml-247"
+        saml_libs_version: "$opensaml-249"
 ]
 
 repositories {


### PR DESCRIPTION
This version includes a fix for a bug where metadata resolvers were not
picking up on changes to a countries trust-anchor.