### PR TITLE
HUB-795: Make test-rp-msa MSA entityId configurable

### DIFF
--- a/configuration/test-rp-msa.yml
+++ b/configuration/test-rp-msa.yml
@@ -15,7 +15,7 @@ logging:
     - type: console
 
 matchingServiceAdapter:
-  entityId: http://www.test-rp-ms.gov.uk/SAML2/MD
+  entityId: ${TEST_RP_MSA_ENTITY_ID:-http://www.test-rp-ms.gov.uk/SAML2/MD}
   externalUrl: ${TEST_RP_MSA_URL}
 
 localMatchingService:


### PR DESCRIPTION
Currently the test-rp MSAs across staging/integration/prod have the same
entity ID. This makes onboarding to self-service impossible.

This change will allow then to be namespaced while maintaining backward
compatibility.