### PR TITLE
HUB-817: Use default trust stores in test-rp msa

### DIFF
--- a/configuration/test-rp-msa.yml
+++ b/configuration/test-rp-msa.yml
@@ -30,12 +30,6 @@ hub:
 metadata:
   url: ${METADATA_URL}
   environment: ${ENVIRONMENT:-INTEGRATION}
-  trustStore:
-    path: ${TRUSTSTORE_PATH}
-    password: ${TRUSTSTORE_PASSWORD}
-  minRefreshDelay: 30000
-  maxRefreshDelay: 1800000
-  expectedEntityId: ${METADATA_ENTITY_ID}
 
 signingKeys:
   primary:


### PR DESCRIPTION
This config file is used by the test-rp MSA in staging and integration.

The integration MSA seems to be struggling to validate the new
federation metadata signature, which is signed by a G3 CA.

Removing this config will allow the MSA to use the default trust stores
which contain the CAs necessary.

Interestingly I've manually inspected the trust store the MSA was using
and it looks like it does contain the G3 CAs. Either way, this change
will eliminate a variable and hopefully make diagnosis of the issue
easier.