### PR TITLE
EID-2031 Update RELEASE_NOTES and build.gradle for release 5.1.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,9 @@ MSA Release Notes
 =================
 
 ### Next
+
+### 5.1.0
+[View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/5.0.0...5.1.0)
 * [Removes matching from european identity schemes](doc/release-details/5.1.0.md), as the UK is longer part of the eIDAS regulation. If the configuration `europeanIdentity.enabled` is currently set to `true`, it must not be removed or changed.
 
 ### 5.0.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 include 'verify-matching-service-test-tool'
 
 gradle.ext {
-    version_number = '5.0.2'
+    version_number = '5.1.0'
 }


### PR DESCRIPTION
Created as part of the [MSA release process](https://verify-team-manual.cloudapps.digital/documentation/support/msa-release/) after running `./do_release verify_matching_service_adapter`. We agreed that this is minor version bump to `5.1.0`, as there is no change in config required.