### PR TITLE
HUB-912: Pull from maven central

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,8 @@ MSA Release Notes
 
 ### Next
 * Use saml-libs release that removes eIDAS code
+* Use Maven central for dependencies.
+
 ### 5.1.0
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/5.0.0...5.1.0)
 * [Removes matching from european identity schemes](doc/release-details/5.1.0.md), as the UK is longer part of the eIDAS regulation. If the configuration `europeanIdentity.enabled` is currently set to `true`, it must not be removed or changed.

--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,6 @@
-buildscript {
-    repositories {
-        if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
-            logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')
-            maven { url 'https://dl.bintray.com/alphagov/maven-test' }
-            maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases' }
-            jcenter()
-        }
-        else {
-            maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }
-        }
-    }
-    dependencies {
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.11.3'
-    }
-}
-
 apply plugin: "java"
 apply plugin: "jacoco"
 apply plugin: 'application'
-apply plugin: 'com.github.ben-manes.versions'
 
 jacoco {
     toolVersion = "0.8.2"
@@ -41,19 +23,16 @@ project.version = "$gradle.ext.version_number-$build_number"
 def dependencyVersions = [
         opensaml:"$opensaml",
         dropwizard: '1.3.5',
-        ida_utils: '386',
-        ida_test_utils: '44',
-        dev_pki: '1.1.0-34',
-        saml_libs_version: "$opensaml-250"
+        ida_utils: '396',
+        ida_test_utils: '65',
+        dev_pki: '2.0.0-45',
+        saml_libs_version: "$opensaml-255"
 ]
 
 repositories {
     if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
         logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')
-        maven { url 'https://dl.bintray.com/alphagov/maven' } // For dropwizard-logstash
-        maven { url 'https://dl.bintray.com/alphagov/maven-test' } // For other public verify binaries
-        maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases' }  // For opensaml
-        jcenter()
+        mavenCentral()
     }
     else {
         maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }
@@ -114,7 +93,7 @@ dependencies {
     runtime "io.dropwizard:dropwizard-metrics-graphite:$dependencyVersions.dropwizard"
 
     ida_test "uk.gov.ida:saml-test:$dependencyVersions.saml_libs_version",
-        "uk.gov.ida:ida-dev-pki:$dependencyVersions.dev_pki"
+        "uk.gov.ida:verify-dev-pki:$dependencyVersions.dev_pki"
 
     testCompile configurations.ida_test,
         'junit:junit:4.11',
@@ -155,6 +134,10 @@ sourceSets {
         compileClasspath += sourceSets.test.runtimeClasspath
         compileClasspath += sourceSets.test.output
     }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
 compileJava {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bintray and jcentre are going away. This updates the public builds to
pull from maven central instead. It also bumps the versions of our
libraries to ensure they're coming from maven central.

It also removes the ben maines plugin which was sold old it didn't work
anymore.