### PR TITLE
[HUB-841] Use Docker Hub rather than GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/verify/gradle:gradle-jdk11 as build
+FROM gradle:6.7.0-jdk11 as build
 
 WORKDIR /msa
 USER root
@@ -19,7 +19,7 @@ RUN gradle installDist
 ENTRYPOINT ["gradle", "--no-daemon"]
 CMD ["tasks"]
 
-FROM ghcr.io/alphagov/verify/java:openjdk-11
+FROM openjdk:11.0.9.1-jre
 
 WORKDIR /msa
 


### PR DESCRIPTION
We've moved back to using Docker Hub rather than github container
registry so I have reverted to previous versions from Docker Hub shown here https://github.com/alphagov/verify-matching-service-adapter/commit/f725b434e50a0c15b4b97663844dba63cb16c66d