### PR TITLE
BAU Pin gradle version to 6.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/verify/gradle:gradle-jdk11 as build
+FROM gradle:6.9.0-jdk11 as build
 
 WORKDIR /msa
 USER root


### PR DESCRIPTION
The build breaks under Gradle 7 so for the time being we have pinned the Gradle version to 6.9.0 and it now pulls from DockerHub as our other repos should now do.