### PR TITLE
BAU Update logback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ language: java
 env:
   global:
     - VERIFY_USE_PUBLIC_BINARIES=true
-    # GITHUB_PAT
-    - secure: "irAXp5LwpciCfXEBytn3plMhuESTh2eROL5biSYUNeYL3AmztVA0LKvFU0BqrbA1AzCCJup7ZNHj/9xVDXhNvWfkvHjSUP/sJgRnBEAdsxU4NT3YcrhLI5nmx+HDbem0kQE/QS72g0zuVXyOqa6RgL/RYYEs2q4KC5OGFPsceKNnMc4TJxTD1sJ0PgowwiEwxL+ZnuW2NT49spr4dothv+c7agzGa4Daz25O2RQmfc8Aal/HN8TzLSU7EfRJDR8axe6wdChvCYLYX1/Jxiy+9/YvHilIgToyq2pKFjBi7T7/krqZ5IRAunKe4pT6lxFKXhkEgDG7kEeJz2SC8eFMM0wUrAX/3QA0P7DAV6iwfD6HtHxniOv2apzJmBpWP9g5wUErUcmoTefMV7fXtmAbGL9flGGHxfkczyr/PFVEO2Vgc20lQ8AdeklE2EZjJ0d2Xhaz9Tr6s3dxQMxkHX06ix72tswKUp/ewaz5EbzD9XkDaPu89d9bYvXbvAtAZKMIpkLUzMfU3QNJQHqJVqqZueKXGRXy3OAKVUMxhr0oStqxDsN//NpX5OeResixns9kbNnMlbSL/jO/evFBNUyng41G2rWV5DflWgq8960iLboMTFXZMrzOCHowciiwhugeuV1bjJb+K3e5CFrKvVceJUIOK3sMJZxDnOrzaS4muLg="
     # CODACY_PROJECT_TOKEN
     - secure: "xJEy2U3/eQ6etkNoqn8SQj6vMlm07qMNn0M25Ufk6LkXlnC497FoZH+kImx+9NwlT+4SzY2qBxNAAE9a7rgDoet/uwfdUfB5j+GEVFuVbglmktGOYZUXPQnVp9u0GJWJg4DMWJiNoeOA4ORKCxETto6/X/qkJ9kF+YMcepU6BuemzGvCcihuMxJuQKgptfhV2EpT3fJLKNm0P+v4GDgPcX9Yuq3exSBcu6Ssm8G/Yf/yrblFEZJIEgiUONSCdlNDEr4vrdIovefsAfYiiCmQh+DYZgtORhek/88IC9d0z7HWuPBWdqMHj1wVv/LVZPxC4MhHwwz2FLAwJ1xZCLVpsVR0YpBZ3I4NFXW7R/2nzBrpaAmF7dvECS05guK3sqcteNQesy/fcp8K49iRaj2zofyiok/0v3ZKjO3hQ+dBcxLYv1Od7v6exD9Px9HBdEMTAynrtXUw0JFQSpOWK7RoZOzwQjMsgWuefY3yl6iL2lJt/3gO+5MV7gE7HaeJb44nLyckBY9hbhtlcSkgKxW2MwAoGCuwdUvEI6MPs7xJDkmacjPbo7NXvDxIiDbvsaUyFubiUlWI0wfiC5Va8Ym2N3gYh/8H9mcrii0G3k1qzpnBlWTXrWKYgDqQw5O72U353hvJzwOA4R5Pjzs8pWj5RxbPavH+s02t+4e0lkY6YpE="
 
@@ -16,7 +14,7 @@ jdk:
 
 before_install:
   - sudo apt-get install jq
-  - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets[] | select(.browser_download_url | contains("codacy-coverage-reporter-assembly"))'.browser_download_url) -o codacy-coverage-reporter-assembly.jar
+  - curl -LSs $(curl -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets[] | select(.browser_download_url | contains("codacy-coverage-reporter-assembly"))'.browser_download_url) -o codacy-coverage-reporter-assembly.jar
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@ MSA Release Notes
 ### Next
 * Use saml-libs release that removes eIDAS code
 * Use Maven central for dependencies.
+* Update logback library to version 1.2.9
 
 ### 5.1.0
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/5.0.0...5.1.0)

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,13 @@ configurations {
     ida_test
 }
 
+configurations.all {
+    resolutionStrategy {
+        force "ch.qos.logback:logback-classic:1.2.9"
+        force "ch.qos.logback:logback-access:1.2.9"
+    }
+}
+
 dependencies {
     dropwizard "io.dropwizard:dropwizard-core:$dependencyVersions.dropwizard",
         "io.dropwizard:dropwizard-util:$dependencyVersions.dropwizard",

--- a/verify-matching-service-test-tool/build.gradle
+++ b/verify-matching-service-test-tool/build.gradle
@@ -7,8 +7,7 @@ apply plugin: 'application'
 repositories {
     if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
         logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')
-        maven { url 'https://dl.bintray.com/alphagov/maven-test' }
-        jcenter()
+        mavenCentral()
     }
     else {
         maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }
@@ -19,8 +18,7 @@ buildscript {
     repositories {
         if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
             logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')
-            maven { url 'https://dl.bintray.com/alphagov/maven-test' }
-            jcenter()
+            mavenCentral()
         }
         else {
             maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }


### PR DESCRIPTION
Update logback to 1.2.9 to mitigate CVE-2021-42550

See the article "16th of December, 2021, Release of version 1.2.9" at http://logback.qos.ch/news.html