### PR TITLE
BAU Update RELEASE_NOTES and build.gradle for release 5.2.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,9 @@ MSA Release Notes
 =================
 
 ### Next
+
+### 5.2.0
+[View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/5.0.0...5.2.0)
 * Use saml-libs release that removes eIDAS code
 * Use Maven central for dependencies.
 * Update logback library to version 1.2.9

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 include 'verify-matching-service-test-tool'
 
 gradle.ext {
-    version_number = '5.1.0'
+    version_number = '5.2.0'
 }


### PR DESCRIPTION
Bump MSA from version 5.1.0 to 5.2.0.

The version number bump will start the MSA release pipeline