### PR TITLE
BAU: Import jersey-media-jaxb

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@ MSA Release Notes
 =================
 
 ### Next
+* Import jersey-media-jaxb to allow local metadata XML to be serialised
 
 ### 5.2.0
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/5.0.0...5.2.0)

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
         "io.dropwizard:dropwizard-metrics-graphite:$dependencyVersions.dropwizard",
         "org.glassfish.hk2:guice-bridge:$dependencyVersions.glassfish_version",
         "org.glassfish.jersey.inject:jersey-hk2:$dependencyVersions.glassfish_jersey_version",
+        "org.glassfish.jersey.media:jersey-media-jaxb:$dependencyVersions.glassfish_jersey_version",
         "com.google.inject.extensions:guice-servlet:5.0.1"
 
     saml "org.opensaml:opensaml-core:$dependencyVersions.opensaml",


### PR DESCRIPTION
One of the quirks of DropWizard 2 was having to import this lib so that
we can return XML media types.

This allows the MSA to serve it's metadata for consumption by RPs.