### PR TITLE
BAU: Update version 5.2.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,10 @@ MSA Release Notes
 
 ### Next
 
+### 5.2.3
+[View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/5.2.1...5.2.3)
+* No functional changes. Released to align version numbers.
+
 ### 5.2.1
 [View Diff](https://github.com/alphagov/verify-matching-service-adapter/compare/5.2.0...5.2.1)
 * Import jersey-media-jaxb to allow local metadata XML to be serialised

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 include 'verify-matching-service-test-tool'
 
 gradle.ext {
-    version_number = '5.2.1'
+    version_number = '5.2.3'
 }


### PR DESCRIPTION
This adds no functional changes. It's being bumped to align version in
the pipeline.

The Concourse pipeline maintains it's own MSA version semver resource
which is used when publishing releases to GitHub. The pipeline bumps the
patch version of this semver resource every time a change is merged.

This means that if you want to release a patch version to GitHub it's
very difficult - the patch number on the semver resource will already be
a few versions ahead of the version defined in `settings.gradle`.

We should decouple the GitHub release version from Concourse's internal
semver resources, but for now this should bring the two into alignment
to get the release out.