### PR TITLE
BAU Get MSA working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,8 +85,11 @@ dependencies {
         'commons-lang:commons-lang:2.6',
         'org.apache.ws.commons:ws-commons-util:1.0.1',
         'com.google.code.findbugs:annotations:3.0.0',
-        'xml-apis:xml-apis:1.0.b2'
-        configurations.saml   {
+        'xml-apis:xml-apis:1.0.b2',
+        'javax.xml.bind:jaxb-api:2.2.3',
+        'org.glassfish.jersey.media:jersey-media-jaxb:2.35'
+
+    configurations.saml   {
             exclude group: 'uk.gov.ida', module: 'dropwizard-saml'
         }
 


### PR DESCRIPTION
The MSA wasn't able to process XML as there were some dependencies required for Dropwizard's magic to work.

Now it seems like the MSA is working again.